### PR TITLE
Remove AssemblyInfoCache workaround

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -31,20 +31,4 @@
       </AssemblyAttribute>
     </ItemGroup>
   </Target>
-  <Target Name="GitMetadataAssemblyInfoCacheFileFix"
-          BeforeTargets="CreateGeneratedAssemblyInfoInputsCacheFile"
-          Condition=" '$(GenerateGitMetadata)' == 'true' ">
-    <ItemGroup>
-      <AssemblyAttribute Include="TemporaryAdditionalHashItem" Condition=" $(CommitHash) != '' or $(CommitBranch) != '' ">
-        <_Parameter1>$(CommitHash);$(CommitBranch)</_Parameter1>
-      </AssemblyAttribute>
-    </ItemGroup>
-  </Target>
-  <Target Name="CleanupTemporaryAdditionalHashItem"
-          AfterTargets="CreateGeneratedAssemblyInfoInputsCacheFile;AddGitMetadaAssemblyAttributes"
-          Condition=" '$(GenerateGitMetadata)' == 'true' ">
-    <ItemGroup>
-      <AssemblyAttribute Remove="TemporaryAdditionalHashItem" />
-    </ItemGroup>
-  </Target>
 </Project>


### PR DESCRIPTION
This work around is not required since SDK `2.1.300`. The [fix was made here](https://github.com/dotnet/sdk/commit/73fb22a07091585380ead0bcbcdc38839a0266e8#diff-5b286bd8dee67543f08738e5605f0d3fR99)