### PR TITLE
Change EnqueueAsync() return type

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -24,11 +24,10 @@
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <GenerateGitMetadata Condition=" ('$(CI)' != '' or '$(TF_BUILD)' != '') and '$(GenerateGitMetadata)' == '' ">true</GenerateGitMetadata>
     <LangVersion>latest</LangVersion>
-    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
     <NeutralLanguage>en-US</NeutralLanguage>
     <NoWarn>$(NoWarn)</NoWarn>
     <NoWarn Condition=" '$(GenerateDocumentationFile)' != 'true' ">$(NoWarn);SA0001</NoWarn>
-    <PackageIconUrl></PackageIconUrl>
+    <PackageIcon></PackageIcon>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/martincostello/lambda-test-server</PackageProjectUrl>
     <PackageReleaseNotes>See $(PackageProjectUrl)/releases for details.</PackageReleaseNotes>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -50,4 +50,7 @@
     <FileVersion Condition=" '$(BUILD_BUILDID)' != '' ">$(VersionPrefix).$(BUILD_BUILDID)</FileVersion>
     <FileVersion Condition=" '$(TRAVIS_BUILD_NUMBER)' != '' ">$(VersionPrefix).$(TRAVIS_BUILD_NUMBER)</FileVersion>
   </PropertyGroup>
+  <ItemGroup Condition=" '$(PackageIcon)' != '' ">
+    <None Include="$(MSBuildThisFileDirectory)$(PackageIcon)" Pack="True" PackagePath="" />
+  </ItemGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -41,7 +41,8 @@
     <SignAssembly>true</SignAssembly>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.1.1</VersionPrefix>
+    <AssemblyVersion>0.2.0.0</AssemblyVersion>
+    <VersionPrefix>0.2.0</VersionPrefix>
     <VersionSuffix Condition=" '$(VersionSuffix)' == '' AND '$(APPVEYOR)' == 'true' AND '$(APPVEYOR_REPO_TAG)' != 'true'">beta$([System.Convert]::ToInt32(`$(APPVEYOR_BUILD_NUMBER)`).ToString(`0000`))</VersionSuffix>
     <VersionSuffix Condition=" '$(VersionSuffix)' == '' AND '$(TF_BUILD)' == 'True'">beta$([System.Convert]::ToInt32(`$(BUILD_BUILDID)`).ToString(`0000`))</VersionSuffix>
     <VersionSuffix Condition=" '$(VersionSuffix)' == '' AND '$(TRAVIS)' == 'true'">beta$([System.Convert]::ToInt32(`$(TRAVIS_BUILD_NUMBER)`).ToString(`0000`))</VersionSuffix>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -47,5 +47,8 @@
     <VersionSuffix Condition=" '$(VersionSuffix)' == '' AND '$(TF_BUILD)' == 'True'">beta$([System.Convert]::ToInt32(`$(BUILD_BUILDID)`).ToString(`0000`))</VersionSuffix>
     <VersionSuffix Condition=" '$(VersionSuffix)' == '' AND '$(TRAVIS)' == 'true'">beta$([System.Convert]::ToInt32(`$(TRAVIS_BUILD_NUMBER)`).ToString(`0000`))</VersionSuffix>
     <VersionSuffix Condition=" '$(APPVEYOR_REPO_TAG)' == 'true' AND '$(APPVEYOR_REPO_TAG_NAME)' != '' AND '$(APPVEYOR_REPO_TAG_NAME.Contains(`-`))' == 'true' ">$(APPVEYOR_REPO_TAG_NAME.Substring($(APPVEYOR_REPO_TAG_NAME.IndexOf(`-`))).Substring(1))</VersionSuffix>
+    <FileVersion Condition=" '$(APPVEYOR_BUILD_NUMBER)' != '' ">$(VersionPrefix).$(APPVEYOR_BUILD_NUMBER)</FileVersion>
+    <FileVersion Condition=" '$(BUILD_BUILDID)' != '' ">$(VersionPrefix).$(BUILD_BUILDID)</FileVersion>
+    <FileVersion Condition=" '$(TRAVIS_BUILD_NUMBER)' != '' ">$(VersionPrefix).$(TRAVIS_BUILD_NUMBER)</FileVersion>
   </PropertyGroup>
 </Project>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 os: Visual Studio 2019
-version: 0.1.1.{build}
+version: 0.2.0.{build}
 
 environment:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true

--- a/src/AwsLambdaTestServer/LambdaTestContext.cs
+++ b/src/AwsLambdaTestServer/LambdaTestContext.cs
@@ -6,25 +6,25 @@ using System.Threading.Channels;
 namespace MartinCostello.Testing.AwsLambdaTestServer
 {
     /// <summary>
-    /// A class representing a message enqueued to be processed by an AWS Lambda function. This class cannot be inherited.
+    /// A class representing the context for an AWS request enqueued to be processed by an AWS Lambda function. This class cannot be inherited.
     /// </summary>
-    public sealed class LambdaTestMessage
+    public sealed class LambdaTestContext
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="LambdaTestMessage"/> class.
+        /// Initializes a new instance of the <see cref="LambdaTestContext"/> class.
         /// </summary>
-        /// <param name="awsRequestId">The AWS request Id to invoke the Lambda function with.</param>
+        /// <param name="request">The request to invoke the Lambda function with.</param>
         /// <param name="reader">The channel reader associated with the response.</param>
-        internal LambdaTestMessage(string awsRequestId, ChannelReader<LambdaTestResponse> reader)
+        internal LambdaTestContext(LambdaTestRequest request, ChannelReader<LambdaTestResponse> reader)
         {
-            AwsRequestId = awsRequestId;
+            Request = request;
             Response = reader;
         }
 
         /// <summary>
-        /// Gets the AWS request Id for the request to the function.
+        /// Gets the request to invoke the Lambda function with.
         /// </summary>
-        public string AwsRequestId { get; }
+        public LambdaTestRequest Request { get; }
 
         /// <summary>
         /// Gets the channel reader which completes once the request is processed by the function.

--- a/src/AwsLambdaTestServer/LambdaTestMessage.cs
+++ b/src/AwsLambdaTestServer/LambdaTestMessage.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Martin Costello, 2019. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Threading.Channels;
+
+namespace MartinCostello.Testing.AwsLambdaTestServer
+{
+    /// <summary>
+    /// A class representing a message enqueued to be processed by an AWS Lambda function. This class cannot be inherited.
+    /// </summary>
+    public sealed class LambdaTestMessage
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LambdaTestMessage"/> class.
+        /// </summary>
+        /// <param name="awsRequestId">The AWS request Id to invoke the Lambda function with.</param>
+        /// <param name="reader">The channel reader associated with the response.</param>
+        internal LambdaTestMessage(string awsRequestId, ChannelReader<LambdaTestResponse> reader)
+        {
+            AwsRequestId = awsRequestId;
+            Response = reader;
+        }
+
+        /// <summary>
+        /// Gets the AWS request Id for the request to the function.
+        /// </summary>
+        public string AwsRequestId { get; }
+
+        /// <summary>
+        /// Gets the channel reader which completes once the request is processed by the function.
+        /// </summary>
+        public ChannelReader<LambdaTestResponse> Response { get; }
+    }
+}

--- a/src/AwsLambdaTestServer/LambdaTestServer.cs
+++ b/src/AwsLambdaTestServer/LambdaTestServer.cs
@@ -116,8 +116,9 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
         /// </summary>
         /// <param name="request">The request to invoke the function with.</param>
         /// <returns>
-        /// A <see cref="Task"/> representing the asynchronous operation to enqueue the request
-        /// which returns a channel reader which completes once the request is processed by the function.
+        /// A <see cref="Task{LambdaTestContext}"/> representing the asynchronous operation to
+        /// enqueue the request which returns a context containg a <see cref="ChannelReader{LambdaTestResponse}"/>
+        /// which completes once the request is processed by the function.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         /// <paramref name="request"/> is <see langword="null"/>.
@@ -128,7 +129,7 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
         /// <exception cref="ObjectDisposedException">
         /// The instance has been disposed.
         /// </exception>
-        public async Task<LambdaTestMessage> EnqueueAsync(LambdaTestRequest request)
+        public async Task<LambdaTestContext> EnqueueAsync(LambdaTestRequest request)
         {
             if (request == null)
             {
@@ -140,7 +141,7 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
 
             var reader = await _handler.EnqueueAsync(request, _onStopped.Token).ConfigureAwait(false);
 
-            return new LambdaTestMessage(request.AwsRequestId, reader);
+            return new LambdaTestContext(request, reader);
         }
 
         /// <summary>

--- a/src/AwsLambdaTestServer/LambdaTestServer.cs
+++ b/src/AwsLambdaTestServer/LambdaTestServer.cs
@@ -128,7 +128,7 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
         /// <exception cref="ObjectDisposedException">
         /// The instance has been disposed.
         /// </exception>
-        public async Task<ChannelReader<LambdaTestResponse>> EnqueueAsync(LambdaTestRequest request)
+        public async Task<LambdaTestMessage> EnqueueAsync(LambdaTestRequest request)
         {
             if (request == null)
             {
@@ -138,7 +138,9 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
             ThrowIfDisposed();
             ThrowIfNotStarted();
 
-            return await _handler.EnqueueAsync(request, _onStopped.Token).ConfigureAwait(false);
+            var reader = await _handler.EnqueueAsync(request, _onStopped.Token).ConfigureAwait(false);
+
+            return new LambdaTestMessage(request.AwsRequestId, reader);
         }
 
         /// <summary>

--- a/src/AwsLambdaTestServer/LambdaTestServerExtensions.cs
+++ b/src/AwsLambdaTestServer/LambdaTestServerExtensions.cs
@@ -30,7 +30,7 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
         /// <exception cref="ObjectDisposedException">
         /// The instance has been disposed.
         /// </exception>
-        public static async Task<ChannelReader<LambdaTestResponse>> EnqueueAsync(
+        public static async Task<LambdaTestMessage> EnqueueAsync(
             this LambdaTestServer server,
             string value)
         {
@@ -64,7 +64,7 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
         /// <exception cref="ObjectDisposedException">
         /// The instance has been disposed.
         /// </exception>
-        public static async Task<ChannelReader<LambdaTestResponse>> EnqueueAsync(
+        public static async Task<LambdaTestMessage> EnqueueAsync(
             this LambdaTestServer server,
             byte[] content)
         {

--- a/src/AwsLambdaTestServer/LambdaTestServerExtensions.cs
+++ b/src/AwsLambdaTestServer/LambdaTestServerExtensions.cs
@@ -21,8 +21,9 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
         /// <param name="server">The server to enqueue the request with.</param>
         /// <param name="value">The request content to process.</param>
         /// <returns>
-        /// A <see cref="Task"/> representing the asynchronous operation to enqueue the request
-        /// which returns a channel reader which completes once the request is processed by the function.
+        /// A <see cref="Task{LambdaTestContext}"/> representing the asynchronous operation to
+        /// enqueue the request which returns a context containg a <see cref="ChannelReader{LambdaTestResponse}"/>
+        /// which completes once the request is processed by the function.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         /// <paramref name="server"/> or <paramref name="value"/> is <see langword="null"/>.
@@ -30,7 +31,7 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
         /// <exception cref="ObjectDisposedException">
         /// The instance has been disposed.
         /// </exception>
-        public static async Task<LambdaTestMessage> EnqueueAsync(
+        public static async Task<LambdaTestContext> EnqueueAsync(
             this LambdaTestServer server,
             string value)
         {
@@ -55,8 +56,9 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
         /// <param name="server">The server to enqueue the request with.</param>
         /// <param name="content">The request content to process.</param>
         /// <returns>
-        /// A <see cref="Task"/> representing the asynchronous operation to enqueue the request
-        /// which returns a channel reader which completes once the request is processed by the function.
+        /// A <see cref="Task{LambdaTestContext}"/> representing the asynchronous operation to
+        /// enqueue the request which returns a context containg a <see cref="ChannelReader{LambdaTestResponse}"/>
+        /// which completes once the request is processed by the function.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         /// <paramref name="server"/> or <paramref name="content"/> is <see langword="null"/>.
@@ -64,7 +66,7 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
         /// <exception cref="ObjectDisposedException">
         /// The instance has been disposed.
         /// </exception>
-        public static async Task<LambdaTestMessage> EnqueueAsync(
+        public static async Task<LambdaTestContext> EnqueueAsync(
             this LambdaTestServer server,
             byte[] content)
         {

--- a/src/AwsLambdaTestServer/PublicAPI.Shipped.txt
+++ b/src/AwsLambdaTestServer/PublicAPI.Shipped.txt
@@ -1,6 +1,6 @@
-MartinCostello.Testing.AwsLambdaTestServer.LambdaTestMessage
-MartinCostello.Testing.AwsLambdaTestServer.LambdaTestMessage.AwsRequestId.get -> string
-MartinCostello.Testing.AwsLambdaTestServer.LambdaTestMessage.Response.get -> System.Threading.Channels.ChannelReader<MartinCostello.Testing.AwsLambdaTestServer.LambdaTestResponse>
+MartinCostello.Testing.AwsLambdaTestServer.LambdaTestContext
+MartinCostello.Testing.AwsLambdaTestServer.LambdaTestContext.Request.get -> MartinCostello.Testing.AwsLambdaTestServer.LambdaTestRequest
+MartinCostello.Testing.AwsLambdaTestServer.LambdaTestContext.Response.get -> System.Threading.Channels.ChannelReader<MartinCostello.Testing.AwsLambdaTestServer.LambdaTestResponse>
 MartinCostello.Testing.AwsLambdaTestServer.LambdaTestRequest
 MartinCostello.Testing.AwsLambdaTestServer.LambdaTestRequest.AwsRequestId.get -> string
 MartinCostello.Testing.AwsLambdaTestServer.LambdaTestRequest.ClientContext.get -> string
@@ -15,7 +15,7 @@ MartinCostello.Testing.AwsLambdaTestServer.LambdaTestResponse.IsSuccessful.get -
 MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServer
 MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServer.CreateClient() -> System.Net.Http.HttpClient
 MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServer.Dispose() -> void
-MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServer.EnqueueAsync(MartinCostello.Testing.AwsLambdaTestServer.LambdaTestRequest request) -> System.Threading.Tasks.Task<MartinCostello.Testing.AwsLambdaTestServer.LambdaTestMessage>
+MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServer.EnqueueAsync(MartinCostello.Testing.AwsLambdaTestServer.LambdaTestRequest request) -> System.Threading.Tasks.Task<MartinCostello.Testing.AwsLambdaTestServer.LambdaTestContext>
 MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServer.LambdaTestServer() -> void
 MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServer.LambdaTestServer(MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServerOptions options) -> void
 MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServer.LambdaTestServer(System.Action<Microsoft.Extensions.DependencyInjection.IServiceCollection> configure) -> void
@@ -43,8 +43,8 @@ MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServerOptions.LogGroupName.
 MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServerOptions.LogStreamName.get -> string
 MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServerOptions.LogStreamName.set -> void
 static MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServer.ClearLambdaEnvironmentVariables() -> void
-static MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServerExtensions.EnqueueAsync(this MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServer server, byte[] content) -> System.Threading.Tasks.Task<MartinCostello.Testing.AwsLambdaTestServer.LambdaTestMessage>
-static MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServerExtensions.EnqueueAsync(this MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServer server, string value) -> System.Threading.Tasks.Task<MartinCostello.Testing.AwsLambdaTestServer.LambdaTestMessage>
+static MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServerExtensions.EnqueueAsync(this MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServer server, byte[] content) -> System.Threading.Tasks.Task<MartinCostello.Testing.AwsLambdaTestServer.LambdaTestContext>
+static MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServerExtensions.EnqueueAsync(this MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServer server, string value) -> System.Threading.Tasks.Task<MartinCostello.Testing.AwsLambdaTestServer.LambdaTestContext>
 virtual MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServer.Configure(Microsoft.AspNetCore.Builder.IApplicationBuilder app) -> void
 virtual MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServer.ConfigureServices(Microsoft.Extensions.DependencyInjection.IServiceCollection services) -> void
 virtual MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServer.ConfigureWebHost(Microsoft.AspNetCore.Hosting.IWebHostBuilder builder) -> void

--- a/src/AwsLambdaTestServer/PublicAPI.Shipped.txt
+++ b/src/AwsLambdaTestServer/PublicAPI.Shipped.txt
@@ -1,3 +1,6 @@
+MartinCostello.Testing.AwsLambdaTestServer.LambdaTestMessage
+MartinCostello.Testing.AwsLambdaTestServer.LambdaTestMessage.AwsRequestId.get -> string
+MartinCostello.Testing.AwsLambdaTestServer.LambdaTestMessage.Response.get -> System.Threading.Channels.ChannelReader<MartinCostello.Testing.AwsLambdaTestServer.LambdaTestResponse>
 MartinCostello.Testing.AwsLambdaTestServer.LambdaTestRequest
 MartinCostello.Testing.AwsLambdaTestServer.LambdaTestRequest.AwsRequestId.get -> string
 MartinCostello.Testing.AwsLambdaTestServer.LambdaTestRequest.ClientContext.get -> string
@@ -12,7 +15,7 @@ MartinCostello.Testing.AwsLambdaTestServer.LambdaTestResponse.IsSuccessful.get -
 MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServer
 MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServer.CreateClient() -> System.Net.Http.HttpClient
 MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServer.Dispose() -> void
-MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServer.EnqueueAsync(MartinCostello.Testing.AwsLambdaTestServer.LambdaTestRequest request) -> System.Threading.Tasks.Task<System.Threading.Channels.ChannelReader<MartinCostello.Testing.AwsLambdaTestServer.LambdaTestResponse>>
+MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServer.EnqueueAsync(MartinCostello.Testing.AwsLambdaTestServer.LambdaTestRequest request) -> System.Threading.Tasks.Task<MartinCostello.Testing.AwsLambdaTestServer.LambdaTestMessage>
 MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServer.LambdaTestServer() -> void
 MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServer.LambdaTestServer(MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServerOptions options) -> void
 MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServer.LambdaTestServer(System.Action<Microsoft.Extensions.DependencyInjection.IServiceCollection> configure) -> void
@@ -40,8 +43,8 @@ MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServerOptions.LogGroupName.
 MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServerOptions.LogStreamName.get -> string
 MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServerOptions.LogStreamName.set -> void
 static MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServer.ClearLambdaEnvironmentVariables() -> void
-static MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServerExtensions.EnqueueAsync(this MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServer server, byte[] content) -> System.Threading.Tasks.Task<System.Threading.Channels.ChannelReader<MartinCostello.Testing.AwsLambdaTestServer.LambdaTestResponse>>
-static MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServerExtensions.EnqueueAsync(this MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServer server, string value) -> System.Threading.Tasks.Task<System.Threading.Channels.ChannelReader<MartinCostello.Testing.AwsLambdaTestServer.LambdaTestResponse>>
+static MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServerExtensions.EnqueueAsync(this MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServer server, byte[] content) -> System.Threading.Tasks.Task<MartinCostello.Testing.AwsLambdaTestServer.LambdaTestMessage>
+static MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServerExtensions.EnqueueAsync(this MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServer server, string value) -> System.Threading.Tasks.Task<MartinCostello.Testing.AwsLambdaTestServer.LambdaTestMessage>
 virtual MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServer.Configure(Microsoft.AspNetCore.Builder.IApplicationBuilder app) -> void
 virtual MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServer.ConfigureServices(Microsoft.Extensions.DependencyInjection.IServiceCollection services) -> void
 virtual MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServer.ConfigureWebHost(Microsoft.AspNetCore.Hosting.IWebHostBuilder builder) -> void

--- a/tests/AwsLambdaTestServer.Tests/Examples.cs
+++ b/tests/AwsLambdaTestServer.Tests/Examples.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Text;
 using System.Threading;
-using System.Threading.Channels;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Shouldly;
@@ -38,12 +37,12 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
 
             // Queue the request with the server to invoke the Lambda function and
             // store the ChannelReader into a variable to use to read the response.
-            ChannelReader<LambdaTestResponse> reader = await server.EnqueueAsync(value);
+            LambdaTestMessage message = await server.EnqueueAsync(value);
 
             // Queue a task to stop the test server from listening as soon as the response is available
             _ = Task.Run(async () =>
             {
-                await reader.WaitToReadAsync(cancellationTokenSource.Token);
+                await message.Response.WaitToReadAsync(cancellationTokenSource.Token);
 
                 if (!cancellationTokenSource.IsCancellationRequested)
                 {
@@ -58,7 +57,7 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
             await MyFunctionEntrypoint.RunAsync(httpClient, cancellationTokenSource.Token);
 
             // Assert - The channel reader should have the response available
-            reader.TryRead(out LambdaTestResponse response).ShouldBeTrue("No Lambda response is available.");
+            message.Response.TryRead(out LambdaTestResponse response).ShouldBeTrue("No Lambda response is available.");
 
             response.ShouldNotBeNull("The Lambda response is null.");
             response.IsSuccessful.ShouldBeTrue("The Lambda function failed to handle the request.");
@@ -70,7 +69,7 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
             actual.Sum.ShouldBe(6, "The Lambda function returned an incorrect response.");
         }
 
-        private static async Task<ChannelReader<LambdaTestResponse>> EnqueueAsync<T>(this LambdaTestServer server, T value)
+        private static async Task<LambdaTestMessage> EnqueueAsync<T>(this LambdaTestServer server, T value)
             where T : class
         {
             string json = JsonConvert.SerializeObject(value);

--- a/tests/AwsLambdaTestServer.Tests/Examples.cs
+++ b/tests/AwsLambdaTestServer.Tests/Examples.cs
@@ -37,12 +37,12 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
 
             // Queue the request with the server to invoke the Lambda function and
             // store the ChannelReader into a variable to use to read the response.
-            LambdaTestMessage message = await server.EnqueueAsync(value);
+            LambdaTestContext context = await server.EnqueueAsync(value);
 
             // Queue a task to stop the test server from listening as soon as the response is available
             _ = Task.Run(async () =>
             {
-                await message.Response.WaitToReadAsync(cancellationTokenSource.Token);
+                await context.Response.WaitToReadAsync(cancellationTokenSource.Token);
 
                 if (!cancellationTokenSource.IsCancellationRequested)
                 {
@@ -57,7 +57,7 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
             await MyFunctionEntrypoint.RunAsync(httpClient, cancellationTokenSource.Token);
 
             // Assert - The channel reader should have the response available
-            message.Response.TryRead(out LambdaTestResponse response).ShouldBeTrue("No Lambda response is available.");
+            context.Response.TryRead(out LambdaTestResponse response).ShouldBeTrue("No Lambda response is available.");
 
             response.ShouldNotBeNull("The Lambda response is null.");
             response.IsSuccessful.ShouldBeTrue("The Lambda function failed to handle the request.");
@@ -69,7 +69,7 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
             actual.Sum.ShouldBe(6, "The Lambda function returned an incorrect response.");
         }
 
-        private static async Task<LambdaTestMessage> EnqueueAsync<T>(this LambdaTestServer server, T value)
+        private static async Task<LambdaTestContext> EnqueueAsync<T>(this LambdaTestServer server, T value)
             where T : class
         {
             string json = JsonConvert.SerializeObject(value);

--- a/tests/AwsLambdaTestServer.Tests/LambdaTestServerTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/LambdaTestServerTests.cs
@@ -142,11 +142,11 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
 
             await server.StartAsync(cts.Token);
 
-            var message = await server.EnqueueAsync(@"{""Values"": [ 1, 2, 3 ]}");
+            var context = await server.EnqueueAsync(@"{""Values"": [ 1, 2, 3 ]}");
 
             _ = Task.Run(async () =>
             {
-                await message.Response.WaitToReadAsync(cts.Token);
+                await context.Response.WaitToReadAsync(cts.Token);
 
                 if (!cts.IsCancellationRequested)
                 {
@@ -160,7 +160,7 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
             await MyFunctionEntrypoint.RunAsync(httpClient, cts.Token);
 
             // Assert
-            message.Response.TryRead(out var response).ShouldBeTrue();
+            context.Response.TryRead(out var response).ShouldBeTrue();
 
             response.ShouldNotBeNull();
             response.IsSuccessful.ShouldBeTrue();
@@ -190,11 +190,11 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
                 CognitoIdentity = "{}",
             };
 
-            var message = await server.EnqueueAsync(request);
+            var context = await server.EnqueueAsync(request);
 
             _ = Task.Run(async () =>
             {
-                await message.Response.WaitToReadAsync(cts.Token);
+                await context.Response.WaitToReadAsync(cts.Token);
 
                 if (!cts.IsCancellationRequested)
                 {
@@ -208,7 +208,7 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
             await MyFunctionEntrypoint.RunAsync(httpClient, cts.Token);
 
             // Assert
-            message.Response.TryRead(out var response).ShouldBeTrue();
+            context.Response.TryRead(out var response).ShouldBeTrue();
 
             response.ShouldNotBeNull();
             response.IsSuccessful.ShouldBeTrue();
@@ -228,11 +228,11 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
 
             await server.StartAsync(cts.Token);
 
-            var message = await server.EnqueueAsync(@"{""Values"": null}");
+            var context = await server.EnqueueAsync(@"{""Values"": null}");
 
             _ = Task.Run(async () =>
             {
-                await message.Response.WaitToReadAsync(cts.Token);
+                await context.Response.WaitToReadAsync(cts.Token);
 
                 if (!cts.IsCancellationRequested)
                 {
@@ -246,7 +246,7 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
             await MyFunctionEntrypoint.RunAsync(httpClient, cts.Token);
 
             // Assert
-            message.Response.TryRead(out var response).ShouldBeTrue();
+            context.Response.TryRead(out var response).ShouldBeTrue();
 
             response.ShouldNotBeNull();
             response.IsSuccessful.ShouldBeFalse();
@@ -267,11 +267,11 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
 
             await server.StartAsync(cts.Token);
 
-            var message = await server.EnqueueAsync(@"{""Values"": null}");
+            var context = await server.EnqueueAsync(@"{""Values"": null}");
 
             _ = Task.Run(async () =>
             {
-                await message.Response.WaitToReadAsync(cts.Token);
+                await context.Response.WaitToReadAsync(cts.Token);
 
                 if (!cts.IsCancellationRequested)
                 {
@@ -300,7 +300,7 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
 
             await server.StartAsync(cts.Token);
 
-            var channels = new List<(int expected, LambdaTestMessage message)>();
+            var channels = new List<(int expected, LambdaTestContext context)>();
 
             for (int i = 0; i < 10; i++)
             {
@@ -316,9 +316,9 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
 
             _ = Task.Run(async () =>
             {
-                foreach ((var _, var message) in channels)
+                foreach ((var _, var context) in channels)
                 {
-                    await message.Response.WaitToReadAsync(cts.Token);
+                    await context.Response.WaitToReadAsync(cts.Token);
                 }
 
                 if (!cts.IsCancellationRequested)
@@ -333,9 +333,9 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
             await MyFunctionEntrypoint.RunAsync(httpClient, cts.Token);
 
             // Assert
-            foreach ((int expected, var message) in channels)
+            foreach ((int expected, var context) in channels)
             {
-                message.Response.TryRead(out var response).ShouldBeTrue();
+                context.Response.TryRead(out var response).ShouldBeTrue();
 
                 response.ShouldNotBeNull();
                 response.IsSuccessful.ShouldBeTrue();


### PR DESCRIPTION
Rather than return the `ChannelReader<T>` directly, wrap it in another type that contains the AWS request Id as well. This makes it easier to extend in the future, as well as pass the Id around with the channel.

Also some minor build changes:

  * Bump the version to 0.2.0 to account for breaking changes.
  * Fix the AssemblyVersion to not include the build number.
  * Include the build number in the file version of the assembly.
  * Remove obsolete `MSBuildAllProjects` property.
  * Replace obsolete `PackageIconUrl` property with `PackageIcon`.
  * Add item to include a package icon in the future if there is one.
