### PR TITLE
Extend server

### DIFF
--- a/src/AwsLambdaTestServer/LambdaTestServer.cs
+++ b/src/AwsLambdaTestServer/LambdaTestServer.cs
@@ -24,6 +24,7 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
 
         private bool _disposed;
         private RuntimeHandler _handler;
+        private bool _isStarted;
         private TestServer _server;
         private CancellationTokenSource _onStopped;
 
@@ -64,6 +65,11 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
         {
             Dispose(false);
         }
+
+        /// <summary>
+        /// Gets a value indicating whether the test Lambda runtime server has been started.
+        /// </summary>
+        public bool IsStarted => _isStarted;
 
         /// <summary>
         /// Gets the options in use by the test Lambda runtime server.
@@ -180,6 +186,8 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
             _handler.Logger = _server.Services.GetRequiredService<ILogger<RuntimeHandler>>();
 
             SetLambdaEnvironmentVariables(_server.BaseAddress);
+
+            _isStarted = true;
 
             return Task.CompletedTask;
         }

--- a/src/AwsLambdaTestServer/LambdaTestServer.cs
+++ b/src/AwsLambdaTestServer/LambdaTestServer.cs
@@ -218,6 +218,7 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
                     }
 
                     _server?.Dispose();
+                    _handler?.Dispose();
                 }
 
                 _disposed = true;

--- a/src/AwsLambdaTestServer/PublicAPI.Shipped.txt
+++ b/src/AwsLambdaTestServer/PublicAPI.Shipped.txt
@@ -16,6 +16,7 @@ MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServer
 MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServer.CreateClient() -> System.Net.Http.HttpClient
 MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServer.Dispose() -> void
 MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServer.EnqueueAsync(MartinCostello.Testing.AwsLambdaTestServer.LambdaTestRequest request) -> System.Threading.Tasks.Task<MartinCostello.Testing.AwsLambdaTestServer.LambdaTestContext>
+MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServer.IsStarted.get -> bool
 MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServer.LambdaTestServer() -> void
 MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServer.LambdaTestServer(MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServerOptions options) -> void
 MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServer.LambdaTestServer(System.Action<Microsoft.Extensions.DependencyInjection.IServiceCollection> configure) -> void

--- a/tests/AwsLambdaTestServer.Tests/Examples.cs
+++ b/tests/AwsLambdaTestServer.Tests/Examples.cs
@@ -66,7 +66,7 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
             response.Content.ShouldNotBeNull("The Lambda function did not return any content.");
 
             string responseJson = Encoding.UTF8.GetString(response.Content);
-            var actual = JsonConvert.DeserializeObject<MyResponse>(requestJson);
+            var actual = JsonConvert.DeserializeObject<MyResponse>(responseJson);
 
             actual.Sum.ShouldBe(6, "The Lambda function returned an incorrect response.");
         }

--- a/tests/AwsLambdaTestServer.Tests/Examples.cs
+++ b/tests/AwsLambdaTestServer.Tests/Examples.cs
@@ -35,9 +35,11 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
                 Values = new[] { 1, 2, 3 }, // The function returns the sum of the specified numbers
             };
 
+            string requestJson = JsonConvert.SerializeObject(value);
+
             // Queue the request with the server to invoke the Lambda function and
             // store the ChannelReader into a variable to use to read the response.
-            LambdaTestContext context = await server.EnqueueAsync(value);
+            LambdaTestContext context = await server.EnqueueAsync(requestJson);
 
             // Queue a task to stop the test server from listening as soon as the response is available
             _ = Task.Run(async () =>
@@ -63,17 +65,10 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
             response.IsSuccessful.ShouldBeTrue("The Lambda function failed to handle the request.");
             response.Content.ShouldNotBeNull("The Lambda function did not return any content.");
 
-            string json = Encoding.UTF8.GetString(response.Content);
-            var actual = JsonConvert.DeserializeObject<MyResponse>(json);
+            string responseJson = Encoding.UTF8.GetString(response.Content);
+            var actual = JsonConvert.DeserializeObject<MyResponse>(requestJson);
 
             actual.Sum.ShouldBe(6, "The Lambda function returned an incorrect response.");
-        }
-
-        private static async Task<LambdaTestContext> EnqueueAsync<T>(this LambdaTestServer server, T value)
-            where T : class
-        {
-            string json = JsonConvert.SerializeObject(value);
-            return await server.EnqueueAsync(json);
         }
     }
 }

--- a/tests/AwsLambdaTestServer.Tests/LambdaTestServerTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/LambdaTestServerTests.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using MartinCostello.Logging.XUnit;
@@ -324,9 +323,7 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
                     Values = Enumerable.Range(1, i + 1).ToArray(),
                 };
 
-                string json = JsonSerializer.Serialize(request);
-
-                channels.Add((request.Values.Sum(), await server.EnqueueAsync(json)));
+                channels.Add((request.Values.Sum(), await server.EnqueueAsync(request)));
             }
 
             _ = Task.Run(async () =>
@@ -356,7 +353,7 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
                 response.IsSuccessful.ShouldBeTrue();
                 response.Content.ShouldNotBeNull();
 
-                var deserialized = JsonSerializer.Deserialize<MyResponse>(response.Content);
+                var deserialized = response.ReadAs<MyResponse>();
                 deserialized.Sum.ShouldBe(expected);
             }
         }

--- a/tests/AwsLambdaTestServer.Tests/LambdaTestServerTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/LambdaTestServerTests.cs
@@ -110,9 +110,17 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
         [Fact]
         public async Task StartAsync_Throws_If_Already_Started()
         {
-            // Arrange
+            // Act
             using var target = new LambdaTestServer();
+
+            // Assert
+            target.IsStarted.ShouldBeFalse();
+
+            // Act
             await target.StartAsync();
+
+            // Assert
+            target.IsStarted.ShouldBeTrue();
 
             // Act and Assert
             await Assert.ThrowsAsync<InvalidOperationException>(async () => await target.StartAsync());
@@ -126,6 +134,7 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
 
             // Act and Assert
             await Assert.ThrowsAsync<ArgumentNullException>("builder",  () => target.StartAsync());
+            target.IsStarted.ShouldBeFalse();
         }
 
         [Fact]

--- a/tests/AwsLambdaTestServer.Tests/ParallelismTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/ParallelismTests.cs
@@ -1,0 +1,115 @@
+﻿// Copyright (c) Martin Costello, 2019. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MartinCostello.Logging.XUnit;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace MartinCostello.Testing.AwsLambdaTestServer
+{
+    public class ParallelismTests : ITestOutputHelperAccessor
+    {
+        public ParallelismTests(ITestOutputHelper outputHelper)
+        {
+            OutputHelper = outputHelper;
+        }
+
+        public ITestOutputHelper OutputHelper { get; set; }
+
+        [Fact(Timeout = 30_000)]
+        public async Task Function_Can_Process_Multiple_Requests_On_Different_Threads()
+        {
+            // Arrange
+            int messageCount = 1_000;
+            int expected = Enumerable.Range(0, messageCount).Sum();
+
+            using var server = new LambdaTestServer();
+            using var cts = new CancellationTokenSource();
+
+            await server.StartAsync(cts.Token);
+
+            using var httpClient = server.CreateClient();
+
+            // Enqueue the requests to process in the background
+            var completedAdding = EnqueueInParallel(messageCount, server);
+
+            // Start a task to consume the responses in the background
+            var completedProcessing = Assert(completedAdding, messageCount, cts);
+
+            // Act - Start the function processing
+            await MyFunctionEntrypoint.RunAsync(httpClient, cts.Token);
+
+            // Assert
+            int actual = await completedProcessing.Task;
+            actual.ShouldBe(expected);
+        }
+
+        private TaskCompletionSource<IReadOnlyCollection<LambdaTestContext>> EnqueueInParallel(
+            int count,
+            LambdaTestServer server)
+        {
+            var collection = new ConcurrentBag<LambdaTestContext>();
+            var completionSource = new TaskCompletionSource<IReadOnlyCollection<LambdaTestContext>>();
+
+            int queued = 0;
+
+            // Enqueue the specified number of items in parallel
+            Parallel.For(0, count, async (i) =>
+            {
+                var request = new MyRequest()
+                {
+                    Values = new[] { i },
+                };
+
+                var context = await server.EnqueueAsync(request);
+
+                collection.Add(context);
+
+                if (Interlocked.Increment(ref queued) == count)
+                {
+                    completionSource.SetResult(collection);
+                }
+            });
+
+            return completionSource;
+        }
+
+        private TaskCompletionSource<int> Assert(
+            TaskCompletionSource<IReadOnlyCollection<LambdaTestContext>> completedAdding,
+            int messages,
+            CancellationTokenSource cts)
+        {
+            var completionSource = new TaskCompletionSource<int>();
+
+            _ = Task.Run(async () =>
+            {
+                var collection = await completedAdding.Task;
+                collection.Count.ShouldBe(messages);
+
+                int actual = 0;
+
+                foreach (var context in collection)
+                {
+                    await context.Response.WaitToReadAsync();
+
+                    var result = await context.Response.ReadAsync();
+
+                    var response = result.ReadAs<MyResponse>();
+
+                    actual += response.Sum;
+                }
+
+                completionSource.SetResult(actual);
+                cts.Cancel();
+            });
+
+            return completionSource;
+        }
+    }
+}

--- a/tests/AwsLambdaTestServer.Tests/TestExtensions.cs
+++ b/tests/AwsLambdaTestServer.Tests/TestExtensions.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Martin Costello, 2019. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace MartinCostello.Testing.AwsLambdaTestServer
+{
+    internal static class TestExtensions
+    {
+        internal static async Task<LambdaTestContext> EnqueueAsync<T>(this LambdaTestServer server, T value)
+            where T : class
+        {
+            string json = JsonConvert.SerializeObject(value);
+            return await server.EnqueueAsync(json);
+        }
+
+        internal static T ReadAs<T>(this LambdaTestResponse response)
+            where T : class
+        {
+            string json = System.Text.Encoding.UTF8.GetString(response.Content);
+            return JsonConvert.DeserializeObject<T>(json);
+        }
+    }
+}


### PR DESCRIPTION
  *  Add `IsStarted` property so the caller can tell if the server has been started or not.
  * Complete any channels in `RuntimeHandler` when the test server is disposed of so no threads waiting for a response are left waiting forever for a value what will never be written.
  * Add more unit tests for `ILambdaContext`, parallel usage and shutting down the server if no requests are ever queued.
