### PR TITLE
Add duration for function invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,31 +336,33 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
 This then outputs logs similar to the below into the xunit test results:
 
 ```
-Test Name:	Function_Reverses_Numbers
+Test Name:	Function_Reverses_Numbers_With_Logging
 Test Outcome:	Passed
 Result StandardOutput:
-[2019-11-03 18:35:28Z] info: Microsoft.AspNetCore.Hosting.Diagnostics[1]
+[2019-11-04 15:21:06Z] info: Microsoft.AspNetCore.Hosting.Diagnostics[1]
       Request starting HTTP/1.1 GET http://localhost/2018-06-01/runtime/invocation/next  
-[2019-11-03 18:35:28Z] info: Microsoft.AspNetCore.Routing.EndpointMiddleware[0]
+[2019-11-04 15:21:06Z] info: Microsoft.AspNetCore.Routing.EndpointMiddleware[0]
       Executing endpoint '/{LambdaVersion}/runtime/invocation/next HTTP: GET'
-[2019-11-03 18:35:28Z] info: MartinCostello.Testing.AwsLambdaTestServer.RuntimeHandler[0]
+[2019-11-04 15:21:06Z] info: MartinCostello.Testing.AwsLambdaTestServer.RuntimeHandler[0]
       Waiting for new request for Lambda function with ARN arn:aws:lambda:eu-west-1:123456789012:function:test-function.
-[2019-11-03 18:35:28Z] info: MartinCostello.Testing.AwsLambdaTestServer.RuntimeHandler[0]
-      Invoking Lambda function with ARN arn:aws:lambda:eu-west-1:123456789012:function:test-function for request Id 0e42d2be-2400-4fc6-a75f-1cc33a91dab3 and trace Id eff856e7-b1e3-4d97-99fb-7686b69b3bc4.
-[2019-11-03 18:35:28Z] info: Microsoft.AspNetCore.Routing.EndpointMiddleware[1]
+[2019-11-04 15:21:06Z] info: MartinCostello.Testing.AwsLambdaTestServer.RuntimeHandler[0]
+      Invoking Lambda function with ARN arn:aws:lambda:eu-west-1:123456789012:function:test-function for request Id 7e1a283d-6268-4401-921c-0d0d67da1da4 and trace Id 51792f7f-2c1e-4934-bfd9-f5f7c6f0d628.
+[2019-11-04 15:21:06Z] info: Microsoft.AspNetCore.Routing.EndpointMiddleware[1]
       Executed endpoint '/{LambdaVersion}/runtime/invocation/next HTTP: GET'
-[2019-11-03 18:35:28Z] info: Microsoft.AspNetCore.Hosting.Diagnostics[2]
-      Request finished in 51.5962ms 200 application/json
-[2019-11-03 18:35:28Z] info: Microsoft.AspNetCore.Hosting.Diagnostics[1]
-      Request starting HTTP/1.1 POST http://localhost/2018-06-01/runtime/invocation/0e42d2be-2400-4fc6-a75f-1cc33a91dab3/response application/json
-[2019-11-03 18:35:28Z] info: Microsoft.AspNetCore.Routing.EndpointMiddleware[0]
+[2019-11-04 15:21:06Z] info: Microsoft.AspNetCore.Hosting.Diagnostics[2]
+      Request finished in 71.9334ms 200 application/json
+[2019-11-04 15:21:06Z] info: Microsoft.AspNetCore.Hosting.Diagnostics[1]
+      Request starting HTTP/1.1 POST http://localhost/2018-06-01/runtime/invocation/7e1a283d-6268-4401-921c-0d0d67da1da4/response application/json 
+[2019-11-04 15:21:06Z] info: Microsoft.AspNetCore.Routing.EndpointMiddleware[0]
       Executing endpoint '/{LambdaVersion}/runtime/invocation/{AwsRequestId}/response HTTP: POST'
-[2019-11-03 18:35:28Z] info: MartinCostello.Testing.AwsLambdaTestServer.RuntimeHandler[0]
-      Invoked Lambda function with ARN arn:aws:lambda:eu-west-1:123456789012:function:test-function for request Id 0e42d2be-2400-4fc6-a75f-1cc33a91dab3: [3,2,1].
-[2019-11-03 18:35:28Z] info: Microsoft.AspNetCore.Routing.EndpointMiddleware[1]
+[2019-11-04 15:21:06Z] info: MartinCostello.Testing.AwsLambdaTestServer.RuntimeHandler[0]
+      Invoked Lambda function with ARN arn:aws:lambda:eu-west-1:123456789012:function:test-function for request Id 7e1a283d-6268-4401-921c-0d0d67da1da4: [3,2,1].
+[2019-11-04 15:21:06Z] info: MartinCostello.Testing.AwsLambdaTestServer.RuntimeHandler[0]
+      Completed processing AWS request Id 7e1a283d-6268-4401-921c-0d0d67da1da4 for Lambda function with ARN arn:aws:lambda:eu-west-1:123456789012:function:test-function in 107 milliseconds.
+[2019-11-04 15:21:06Z] info: Microsoft.AspNetCore.Routing.EndpointMiddleware[1]
       Executed endpoint '/{LambdaVersion}/runtime/invocation/{AwsRequestId}/response HTTP: POST'
-[2019-11-03 18:35:28Z] info: Microsoft.AspNetCore.Hosting.Diagnostics[2]
-      Request finished in 20.2114ms 204
+[2019-11-04 15:21:06Z] info: Microsoft.AspNetCore.Hosting.Diagnostics[2]
+      Request finished in 26.6306ms 204 
 ```
 
 ## Feedback

--- a/src/AwsLambdaTestServer/LambdaTestResponse.cs
+++ b/src/AwsLambdaTestServer/LambdaTestResponse.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Martin Costello, 2019. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
+
 namespace MartinCostello.Testing.AwsLambdaTestServer
 {
     /// <summary>
@@ -13,9 +15,11 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
         /// </summary>
         /// <param name="content">The raw content of the response from the Lambda function.</param>
         /// <param name="isSuccessful">Whether the response indicates the request was successfully handled.</param>
-        internal LambdaTestResponse(byte[] content, bool isSuccessful)
+        /// <param name="duration">The duration of the Lambda function invocation.</param>
+        internal LambdaTestResponse(byte[] content, bool isSuccessful, TimeSpan duration)
         {
             Content = content;
+            Duration = duration;
             IsSuccessful = isSuccessful;
         }
 
@@ -25,6 +29,11 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
 #pragma warning disable CA1819
         public byte[] Content { get; }
 #pragma warning restore CA1819
+
+        /// <summary>
+        /// Gets the approximate duration of the Lambda function invocation.
+        /// </summary>
+        public TimeSpan Duration { get; }
 
         /// <summary>
         /// Gets a value indicating whether the response indicates the request was successfully handled.

--- a/src/AwsLambdaTestServer/PublicAPI.Shipped.txt
+++ b/src/AwsLambdaTestServer/PublicAPI.Shipped.txt
@@ -11,6 +11,7 @@ MartinCostello.Testing.AwsLambdaTestServer.LambdaTestRequest.Content.get -> byte
 MartinCostello.Testing.AwsLambdaTestServer.LambdaTestRequest.LambdaTestRequest(byte[] content, string awsRequestId = null) -> void
 MartinCostello.Testing.AwsLambdaTestServer.LambdaTestResponse
 MartinCostello.Testing.AwsLambdaTestServer.LambdaTestResponse.Content.get -> byte[]
+MartinCostello.Testing.AwsLambdaTestServer.LambdaTestResponse.Duration.get -> System.TimeSpan
 MartinCostello.Testing.AwsLambdaTestServer.LambdaTestResponse.IsSuccessful.get -> bool
 MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServer
 MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServer.CreateClient() -> System.Net.Http.HttpClient

--- a/src/AwsLambdaTestServer/RuntimeHandler.cs
+++ b/src/AwsLambdaTestServer/RuntimeHandler.cs
@@ -167,8 +167,6 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
                 request.AwsRequestId,
                 traceId);
 
-            _responses.GetOrAdd(request.AwsRequestId, (_) => Channel.CreateBounded<LambdaTestResponse>(1));
-
             // These headers are required, as otherwise an exception is thrown
             httpContext.Response.Headers.Add("Lambda-Runtime-Aws-Request-Id", request.AwsRequestId);
             httpContext.Response.Headers.Add("Lambda-Runtime-Invoked-Function-Arn", _options.FunctionArn);

--- a/src/AwsLambdaTestServer/RuntimeHandler.cs
+++ b/src/AwsLambdaTestServer/RuntimeHandler.cs
@@ -330,6 +330,12 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
 
             context.DurationTimer.Stop();
 
+            Logger.LogInformation(
+                "Completed processing AWS request Id {AwsRequestId} for Lambda function with ARN {FunctionArn} in {FunctionDuration} milliseconds.",
+                awsRequestId,
+                _options.FunctionArn,
+                context.DurationTimer.ElapsedMilliseconds);
+
             // Make the response available to read by the enqueuer
             var response = new LambdaTestResponse(content, isSuccessful, context.DurationTimer.Elapsed);
             await context.Channel.Writer.WriteAsync(response, cancellationToken);

--- a/tests/AwsLambdaTestServer.Tests/LambdaTestServerTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/LambdaTestServerTests.cs
@@ -185,6 +185,7 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
             response.ShouldNotBeNull();
             response.IsSuccessful.ShouldBeTrue();
             response.Content.ShouldNotBeNull();
+            response.Duration.ShouldBeGreaterThan(TimeSpan.Zero);
             Encoding.UTF8.GetString(response.Content).ShouldBe(@"{""Sum"":6}");
         }
 


### PR DESCRIPTION
  * Measure the approximate time a Lambda function takes to be invoked and make available as a property on the `LambdaTestResponse` class.
  * Remove a redundant call to `GetOrAdd()` on the responses dictionary.
