### PR TITLE
Support building tags in Azure Pipelines

### DIFF
--- a/.azure-pipelines/build.yml
+++ b/.azure-pipelines/build.yml
@@ -5,6 +5,9 @@ trigger:
   branches:
     include:
     - master
+  tags:
+    include:
+    - v*
 
 phases:
 - template: build-template.yml

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -46,6 +46,8 @@
     <VersionSuffix Condition=" '$(VersionSuffix)' == '' AND '$(TF_BUILD)' == 'True'">beta$([System.Convert]::ToInt32(`$(BUILD_BUILDID)`).ToString(`0000`))</VersionSuffix>
     <VersionSuffix Condition=" '$(VersionSuffix)' == '' AND '$(TRAVIS)' == 'true'">beta$([System.Convert]::ToInt32(`$(TRAVIS_BUILD_NUMBER)`).ToString(`0000`))</VersionSuffix>
     <VersionSuffix Condition=" '$(APPVEYOR_REPO_TAG)' == 'true' AND '$(APPVEYOR_REPO_TAG_NAME)' != '' AND '$(APPVEYOR_REPO_TAG_NAME.Contains(`-`))' == 'true' ">$(APPVEYOR_REPO_TAG_NAME.Substring($(APPVEYOR_REPO_TAG_NAME.IndexOf(`-`))).Substring(1))</VersionSuffix>
+    <VersionPrefix Condition=" $(BUILD_SOURCEBRANCH.StartsWith(`refs/tags/v`)) ">$(BUILD_SOURCEBRANCH.Replace('refs/tags/v', ''))</VersionPrefix>
+    <VersionSuffix Condition=" $(BUILD_SOURCEBRANCH.StartsWith(`refs/tags/v`)) "></VersionSuffix>
     <FileVersion Condition=" '$(APPVEYOR_BUILD_NUMBER)' != '' ">$(VersionPrefix).$(APPVEYOR_BUILD_NUMBER)</FileVersion>
     <FileVersion Condition=" '$(BUILD_BUILDID)' != '' ">$(VersionPrefix).$(BUILD_BUILDID)</FileVersion>
     <FileVersion Condition=" '$(TRAVIS_BUILD_NUMBER)' != '' ">$(VersionPrefix).$(TRAVIS_BUILD_NUMBER)</FileVersion>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -41,7 +41,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyVersion>0.2.0.0</AssemblyVersion>
-    <VersionPrefix>0.2.0</VersionPrefix>
+    <VersionPrefix>0.2.1</VersionPrefix>
     <VersionSuffix Condition=" '$(VersionSuffix)' == '' AND '$(APPVEYOR)' == 'true' AND '$(APPVEYOR_REPO_TAG)' != 'true'">beta$([System.Convert]::ToInt32(`$(APPVEYOR_BUILD_NUMBER)`).ToString(`0000`))</VersionSuffix>
     <VersionSuffix Condition=" '$(VersionSuffix)' == '' AND '$(TF_BUILD)' == 'True'">beta$([System.Convert]::ToInt32(`$(BUILD_BUILDID)`).ToString(`0000`))</VersionSuffix>
     <VersionSuffix Condition=" '$(VersionSuffix)' == '' AND '$(TRAVIS)' == 'true'">beta$([System.Convert]::ToInt32(`$(TRAVIS_BUILD_NUMBER)`).ToString(`0000`))</VersionSuffix>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 os: Visual Studio 2019
-version: 0.2.0.{build}
+version: 0.2.1.{build}
 
 environment:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true


### PR DESCRIPTION
Support building from tags in Azure Pipelines as a backup for manually queuing builds there if AppVeyor triggers for new tag pushes aren't working.
