### PR TITLE
Remove workarounds for Amazon.Lambda.RuntimeSupport

### DIFF
--- a/src/AwsLambdaTestServer/RuntimeHandler.cs
+++ b/src/AwsLambdaTestServer/RuntimeHandler.cs
@@ -151,11 +151,9 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
                     "Stopped listening for additional requests for Lambda function with ARN {FunctionArn}.",
                     _options.FunctionArn);
 
-                // Send a dummy response to prevent the listen loop from erroring
-                request = new LambdaTestRequest(new[] { (byte)'{', (byte)'}' }, "xx-lambda-test-server-stopped-xx");
-
-                // This dummy request wasn't enqueued, so it needs manually adding
-                _responses.GetOrAdd(request.AwsRequestId, (_) => new ResponseContext(Channel.CreateBounded<LambdaTestResponse>(1)));
+                // Throw back into LambdaBootstrap, which will then stop processing.
+                // See https://github.com/aws/aws-lambda-dotnet/pull/540 for details of the change.
+                throw;
             }
 
             // Write the response for the Lambda runtime to pass to the function to invoke

--- a/tests/AwsLambdaTestServer.Tests/FunctionRunner.cs
+++ b/tests/AwsLambdaTestServer.Tests/FunctionRunner.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using System.Net.Http;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Amazon.Lambda.RuntimeSupport;
@@ -19,17 +18,7 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
             var serializer = new JsonSerializer();
 
             using var handlerWrapper = HandlerWrapper.GetHandlerWrapper<MyRequest, MyResponse>(handler.SumAsync, serializer);
-            using var bootstrap = new LambdaBootstrap(handlerWrapper, handler.InitializeAsync);
-
-            if (httpClient != null)
-            {
-                // Replace the internal runtime API client with one using the specified HttpClient.
-                // See https://github.com/aws/aws-lambda-dotnet/blob/4f9142b95b376bd238bce6be43f4e1ec1f983592/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/LambdaBootstrap.cs#L41
-                var client = new RuntimeApiClient(httpClient);
-
-                var property = typeof(LambdaBootstrap).GetProperty("Client", BindingFlags.Instance | BindingFlags.NonPublic);
-                property.SetValue(bootstrap, client);
-            }
+            using var bootstrap = new LambdaBootstrap(httpClient, handlerWrapper, handler.InitializeAsync);
 
             await bootstrap.RunAsync(cancellationToken);
         }

--- a/tests/AwsLambdaTestServer.Tests/LambdaTestServerTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/LambdaTestServerTests.cs
@@ -7,7 +7,6 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
-using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -392,9 +391,11 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
         public void Finalizer_Does_Not_Throw()
         {
 #pragma warning disable CA2000
+#pragma warning disable IDE0067
             // Act (no Assert)
             _ = new LambdaTestServer();
 #pragma warning restore CA2000
+#pragma warning restore IDE0067
         }
 
         [Fact]
@@ -474,17 +475,7 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
             internal static async Task RunAsync(HttpClient httpClient, CancellationToken cancellationToken)
             {
                 var handler = new CustomHandler();
-                using var bootstrap = new LambdaBootstrap(handler.InvokeAsync);
-
-                if (httpClient != null)
-                {
-                    // Replace the internal runtime API client with one using the specified HttpClient.
-                    // See https://github.com/aws/aws-lambda-dotnet/blob/4f9142b95b376bd238bce6be43f4e1ec1f983592/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/LambdaBootstrap.cs#L41
-                    var client = new RuntimeApiClient(httpClient);
-
-                    var property = typeof(LambdaBootstrap).GetProperty("Client", BindingFlags.Instance | BindingFlags.NonPublic);
-                    property.SetValue(bootstrap, client);
-                }
+                using var bootstrap = new LambdaBootstrap(httpClient, handler.InvokeAsync);
 
                 await bootstrap.RunAsync(cancellationToken);
             }

--- a/tests/AwsLambdaTestServer.Tests/ReverseFunction.cs
+++ b/tests/AwsLambdaTestServer.Tests/ReverseFunction.cs
@@ -3,7 +3,6 @@
 
 using System.Linq;
 using System.Net.Http;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Amazon.Lambda.RuntimeSupport;
@@ -23,17 +22,7 @@ namespace MyFunctions
             var serializer = new JsonSerializer();
 
             using var handlerWrapper = HandlerWrapper.GetHandlerWrapper<int[], int[]>(ReverseAsync, serializer);
-            using var bootstrap = new LambdaBootstrap(handlerWrapper);
-
-            if (httpClient != null)
-            {
-                // Use reflection to assign the HttpClient to the LambdaBootstrap instance
-                var client = new RuntimeApiClient(httpClient);
-                var type = bootstrap.GetType();
-                var property = type.GetProperty("Client", BindingFlags.Instance | BindingFlags.NonPublic);
-
-                property.SetValue(bootstrap, client);
-            }
+            using var bootstrap = new LambdaBootstrap(httpClient ?? new HttpClient(), handlerWrapper);
 
             await bootstrap.RunAsync(cancellationToken);
         }


### PR DESCRIPTION
React to changes from https://github.com/aws/aws-lambda-dotnet/pull/540 and remove workarounds required to plug in the Lambda test server that were needed with v1.0.0 of Amazon.Lambda.RuntimeSupport that aren't required with changes made in v1.1.0.
