### PR TITLE
UX Improvements

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -40,8 +40,8 @@
     <SignAssembly>true</SignAssembly>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <AssemblyVersion>0.2.0.0</AssemblyVersion>
-    <VersionPrefix>0.2.2</VersionPrefix>
+    <AssemblyVersion>0.3.0.0</AssemblyVersion>
+    <VersionPrefix>0.3.0</VersionPrefix>
     <VersionSuffix Condition=" '$(VersionSuffix)' == '' AND '$(APPVEYOR)' == 'true' AND '$(APPVEYOR_REPO_TAG)' != 'true'">beta$([System.Convert]::ToInt32(`$(APPVEYOR_BUILD_NUMBER)`).ToString(`0000`))</VersionSuffix>
     <VersionSuffix Condition=" '$(VersionSuffix)' == '' AND '$(TF_BUILD)' == 'True'">beta$([System.Convert]::ToInt32(`$(BUILD_BUILDID)`).ToString(`0000`))</VersionSuffix>
     <VersionSuffix Condition=" '$(VersionSuffix)' == '' AND '$(TRAVIS)' == 'true'">beta$([System.Convert]::ToInt32(`$(TRAVIS_BUILD_NUMBER)`).ToString(`0000`))</VersionSuffix>

--- a/README.md
+++ b/README.md
@@ -100,7 +100,6 @@ namespace MyFunctions
 
             // Assert
             Assert.True(context.Response.TryRead(out LambdaTestResponse response));
-            Assert.NotNull(response);
             Assert.True(response.IsSuccessful);
 
             json = await response.ReadAsStringAsync();
@@ -177,7 +176,6 @@ namespace MyFunctions
 
             // Assert
             Assert.True(context.Response.TryRead(out LambdaTestResponse response));
-            Assert.NotNull(response);
             Assert.True(response.IsSuccessful);
 
             json = await response.ReadAsStringAsync();
@@ -239,7 +237,6 @@ namespace MyFunctions
 
             // Assert
             Assert.True(context.Response.TryRead(out LambdaTestResponse response));
-            Assert.NotNull(response);
             Assert.True(response.IsSuccessful);
 
             json = await response.ReadAsStringAsync();
@@ -304,7 +301,6 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
 
             // Assert
             Assert.True(context.Response.TryRead(out LambdaTestResponse response));
-            Assert.NotNull(response);
             Assert.True(response.IsSuccessful);
 
             json = await response.ReadAsStringAsync();

--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ Here's an example using xunit to verify that `ReverseFunction` works as intended
 
 ```csharp
 using System;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using MartinCostello.Testing.AwsLambdaTestServer;
@@ -103,9 +102,8 @@ namespace MyFunctions
             Assert.True(context.Response.TryRead(out LambdaTestResponse response));
             Assert.NotNull(response);
             Assert.True(response.IsSuccessful);
-            Assert.NotNull(response.Content);
 
-            json = Encoding.UTF8.GetString(response.Content);
+            json = await response.ReadAsStringAsync();
             int[] actual = JsonConvert.DeserializeObject<int[]>(json);
 
             Assert.Equal(new[] { 3, 2, 1 }, actual);
@@ -141,7 +139,6 @@ An example of providing these values from an xunit test is shown below:
 
 ```csharp
 using System;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using MartinCostello.Testing.AwsLambdaTestServer;
@@ -182,9 +179,8 @@ namespace MyFunctions
             Assert.True(context.Response.TryRead(out LambdaTestResponse response));
             Assert.NotNull(response);
             Assert.True(response.IsSuccessful);
-            Assert.NotNull(response.Content);
 
-            json = Encoding.UTF8.GetString(response.Content);
+            json = await response.ReadAsStringAsync();
             int[] actual = JsonConvert.DeserializeObject<int[]>(json);
 
             Assert.Equal(new[] { 3, 2, 1 }, actual);
@@ -205,7 +201,6 @@ An example of this customisation for an xunit test is shown below:
 
 ```csharp
 using System;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using MartinCostello.Testing.AwsLambdaTestServer;
@@ -246,9 +241,8 @@ namespace MyFunctions
             Assert.True(context.Response.TryRead(out LambdaTestResponse response));
             Assert.NotNull(response);
             Assert.True(response.IsSuccessful);
-            Assert.NotNull(response.Content);
 
-            json = Encoding.UTF8.GetString(response.Content);
+            json = await response.ReadAsStringAsync();
             int[] actual = JsonConvert.DeserializeObject<int[]>(json);
 
             Assert.Equal(new[] { 3, 2, 1 }, actual);
@@ -265,7 +259,6 @@ Here's an example of configuring the test server to route its logs to xunit usin
 
 ```csharp
 using System;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using MartinCostello.Logging.XUnit;
@@ -313,9 +306,8 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
             Assert.True(context.Response.TryRead(out LambdaTestResponse response));
             Assert.NotNull(response);
             Assert.True(response.IsSuccessful);
-            Assert.NotNull(response.Content);
 
-            json = Encoding.UTF8.GetString(response.Content);
+            json = await response.ReadAsStringAsync();
             int[] actual = JsonConvert.DeserializeObject<int[]>(json);
 
             Assert.Equal(new[] { 3, 2, 1 }, actual);

--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ The key parts to call out here are:
   1. Once the function processing completes after the `CancellationToken` is signalled, the channel reader is read to obtain the `LambdaTestResponse` for the request that was enqueued.
   1. Once this is returned from the channel reader, the response is checked for success using `IsSuccessful` and then the `Content` (which is a `byte[]`) is deserialized into the expected response to be asserted on. Again, you could make your own extensions to deserialize the response content into `string` or objects from JSON.
 
+The library itself targets `netcoreapp3.0` so requires your test project to target at least .NET Core 3.0, but the function you're testing could target a previous version such as .NET Core 2.2.
+
 ### Examples
 
 You can find examples of how to factor your Lambda function and how to test it:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 os: Visual Studio 2019
-version: 0.2.2.{build}
+version: 0.3.0.{build}
 
 environment:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true

--- a/samples/MathsFunctions.Tests/MathsFunctionTests.cs
+++ b/samples/MathsFunctions.Tests/MathsFunctionTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using System;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using MartinCostello.Testing.AwsLambdaTestServer;
@@ -41,7 +40,7 @@ namespace MathsFunctions
             Assert.True(context.Response.TryRead(out var response));
             Assert.True(response.IsSuccessful);
 
-            json = Encoding.UTF8.GetString(response.Content);
+            json = await response.ReadAsStringAsync();
             var actual = JsonConvert.DeserializeObject<MathsResponse>(json);
 
             Assert.Equal(expected, actual.Result);

--- a/src/AwsLambdaTestServer/LambdaTestResponseExtensions.cs
+++ b/src/AwsLambdaTestServer/LambdaTestResponseExtensions.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Martin Costello, 2019. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace MartinCostello.Testing.AwsLambdaTestServer
+{
+    /// <summary>
+    /// A class containing extension methods for the <see cref="LambdaTestResponse"/> class. This class cannot be inherited.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static class LambdaTestResponseExtensions
+    {
+        /// <summary>
+        /// Reads the content of the specified response as a string as an asynchronous operation.
+        /// </summary>
+        /// <param name="response">The response to read as a string.</param>
+        /// <returns>
+        /// A <see cref="Task{TResult}"/> representing the asynchronous operation to
+        /// read the content of the specified response as a <see langword="string"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="response"/> is <see langword="null"/>.
+        /// </exception>
+        public static async Task<string> ReadAsStringAsync(this LambdaTestResponse response)
+        {
+            if (response == null)
+            {
+                throw new ArgumentNullException(nameof(response));
+            }
+
+            using var stream = new MemoryStream(response.Content);
+            using var reader = new StreamReader(stream);
+
+            return await reader.ReadToEndAsync().ConfigureAwait(false);
+        }
+    }
+}

--- a/src/AwsLambdaTestServer/PublicAPI.Shipped.txt
+++ b/src/AwsLambdaTestServer/PublicAPI.Shipped.txt
@@ -13,6 +13,7 @@ MartinCostello.Testing.AwsLambdaTestServer.LambdaTestResponse
 MartinCostello.Testing.AwsLambdaTestServer.LambdaTestResponse.Content.get -> byte[]
 MartinCostello.Testing.AwsLambdaTestServer.LambdaTestResponse.Duration.get -> System.TimeSpan
 MartinCostello.Testing.AwsLambdaTestServer.LambdaTestResponse.IsSuccessful.get -> bool
+MartinCostello.Testing.AwsLambdaTestServer.LambdaTestResponseExtensions
 MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServer
 MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServer.CreateClient() -> System.Net.Http.HttpClient
 MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServer.Dispose() -> void
@@ -44,6 +45,7 @@ MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServerOptions.LogGroupName.
 MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServerOptions.LogGroupName.set -> void
 MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServerOptions.LogStreamName.get -> string
 MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServerOptions.LogStreamName.set -> void
+static MartinCostello.Testing.AwsLambdaTestServer.LambdaTestResponseExtensions.ReadAsStringAsync(this MartinCostello.Testing.AwsLambdaTestServer.LambdaTestResponse response) -> System.Threading.Tasks.Task<string>
 static MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServer.ClearLambdaEnvironmentVariables() -> void
 static MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServerExtensions.EnqueueAsync(this MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServer server, byte[] content) -> System.Threading.Tasks.Task<MartinCostello.Testing.AwsLambdaTestServer.LambdaTestContext>
 static MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServerExtensions.EnqueueAsync(this MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServer server, string value) -> System.Threading.Tasks.Task<MartinCostello.Testing.AwsLambdaTestServer.LambdaTestContext>

--- a/tests/AwsLambdaTestServer.Tests/Examples.cs
+++ b/tests/AwsLambdaTestServer.Tests/Examples.cs
@@ -60,7 +60,6 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
             // Assert - The channel reader should have the response available
             context.Response.TryRead(out LambdaTestResponse response).ShouldBeTrue("No Lambda response is available.");
 
-            response.ShouldNotBeNull("The Lambda response is null.");
             response.IsSuccessful.ShouldBeTrue("The Lambda function failed to handle the request.");
             response.Content.ShouldNotBeEmpty("The Lambda function did not return any content.");
 

--- a/tests/AwsLambdaTestServer.Tests/Examples.cs
+++ b/tests/AwsLambdaTestServer.Tests/Examples.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using System;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
@@ -63,9 +62,9 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
 
             response.ShouldNotBeNull("The Lambda response is null.");
             response.IsSuccessful.ShouldBeTrue("The Lambda function failed to handle the request.");
-            response.Content.ShouldNotBeNull("The Lambda function did not return any content.");
+            response.Content.ShouldNotBeEmpty("The Lambda function did not return any content.");
 
-            string responseJson = Encoding.UTF8.GetString(response.Content);
+            string responseJson = await response.ReadAsStringAsync();
             var actual = JsonConvert.DeserializeObject<MyResponse>(responseJson);
 
             actual.Sum.ShouldBe(6, "The Lambda function returned an incorrect response.");

--- a/tests/AwsLambdaTestServer.Tests/LambdaTestResponseExtensionsTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/LambdaTestResponseExtensionsTests.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Martin Costello, 2019. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace MartinCostello.Testing.AwsLambdaTestServer
+{
+    public static class LambdaTestResponseExtensionsTests
+    {
+        [Fact]
+        public static async Task EnqueueAsync_Validates_Parameters()
+        {
+            // Arrange
+            LambdaTestResponse response = null;
+
+            // Act
+            await Assert.ThrowsAsync<ArgumentNullException>("response", () => response.ReadAsStringAsync());
+        }
+    }
+}

--- a/tests/AwsLambdaTestServer.Tests/LambdaTestServerTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/LambdaTestServerTests.cs
@@ -359,7 +359,7 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
                 response.IsSuccessful.ShouldBeTrue();
                 response.Content.ShouldNotBeNull();
 
-                var deserialized = response.ReadAs<MyResponse>();
+                var deserialized = await response.ReadAsAsync<MyResponse>();
                 deserialized.Sum.ShouldBe(expected);
             }
         }
@@ -451,7 +451,7 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
             response.IsSuccessful.ShouldBeTrue();
             response.Content.ShouldNotBeNull();
 
-            var lambdaContext = response.ReadAs<IDictionary<string, string>>();
+            var lambdaContext = await response.ReadAsAsync<IDictionary<string, string>>();
             lambdaContext.ShouldContainKeyAndValue("AwsRequestId", request.AwsRequestId);
             lambdaContext.ShouldContainKeyAndValue("ClientContext", "my-app");
             lambdaContext.ShouldContainKeyAndValue("FunctionName", options.FunctionName);

--- a/tests/AwsLambdaTestServer.Tests/ParallelismTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/ParallelismTests.cs
@@ -87,7 +87,7 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
 
                     var result = await context.Response.ReadAsync();
 
-                    var response = result.ReadAs<int[]>();
+                    var response = await result.ReadAsAsync<int[]>();
 
                     actual += response[0];
                 }

--- a/tests/AwsLambdaTestServer.Tests/ReverseFunctionTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/ReverseFunctionTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using System;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using MartinCostello.Testing.AwsLambdaTestServer;
@@ -36,9 +35,8 @@ namespace MyFunctions
             Assert.True(context.Response.TryRead(out LambdaTestResponse response));
             Assert.NotNull(response);
             Assert.True(response.IsSuccessful);
-            Assert.NotNull(response.Content);
 
-            json = Encoding.UTF8.GetString(response.Content);
+            json = await response.ReadAsStringAsync();
             int[] actual = JsonConvert.DeserializeObject<int[]>(json);
 
             Assert.Equal(new[] { 3, 2, 1 }, actual);

--- a/tests/AwsLambdaTestServer.Tests/ReverseFunctionTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/ReverseFunctionTests.cs
@@ -33,7 +33,6 @@ namespace MyFunctions
 
             // Assert
             Assert.True(context.Response.TryRead(out LambdaTestResponse response));
-            Assert.NotNull(response);
             Assert.True(response.IsSuccessful);
 
             json = await response.ReadAsStringAsync();

--- a/tests/AwsLambdaTestServer.Tests/ReverseFunctionWithCustomOptionsTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/ReverseFunctionWithCustomOptionsTests.cs
@@ -40,7 +40,6 @@ namespace MyFunctions
 
             // Assert
             Assert.True(context.Response.TryRead(out LambdaTestResponse response));
-            Assert.NotNull(response);
             Assert.True(response.IsSuccessful);
 
             json = await response.ReadAsStringAsync();

--- a/tests/AwsLambdaTestServer.Tests/ReverseFunctionWithCustomOptionsTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/ReverseFunctionWithCustomOptionsTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using System;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using MartinCostello.Testing.AwsLambdaTestServer;
@@ -43,9 +42,8 @@ namespace MyFunctions
             Assert.True(context.Response.TryRead(out LambdaTestResponse response));
             Assert.NotNull(response);
             Assert.True(response.IsSuccessful);
-            Assert.NotNull(response.Content);
 
-            json = Encoding.UTF8.GetString(response.Content);
+            json = await response.ReadAsStringAsync();
             int[] actual = JsonConvert.DeserializeObject<int[]>(json);
 
             Assert.Equal(new[] { 3, 2, 1 }, actual);

--- a/tests/AwsLambdaTestServer.Tests/ReverseFunctionWithLoggingTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/ReverseFunctionWithLoggingTests.cs
@@ -47,7 +47,6 @@ namespace MyFunctions
 
             // Assert
             Assert.True(context.Response.TryRead(out LambdaTestResponse response));
-            Assert.NotNull(response);
             Assert.True(response.IsSuccessful);
 
             json = await response.ReadAsStringAsync();

--- a/tests/AwsLambdaTestServer.Tests/ReverseFunctionWithLoggingTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/ReverseFunctionWithLoggingTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using System;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using MartinCostello.Logging.XUnit;
@@ -50,9 +49,8 @@ namespace MyFunctions
             Assert.True(context.Response.TryRead(out LambdaTestResponse response));
             Assert.NotNull(response);
             Assert.True(response.IsSuccessful);
-            Assert.NotNull(response.Content);
 
-            json = Encoding.UTF8.GetString(response.Content);
+            json = await response.ReadAsStringAsync();
             int[] actual = JsonConvert.DeserializeObject<int[]>(json);
 
             Assert.Equal(new[] { 3, 2, 1 }, actual);

--- a/tests/AwsLambdaTestServer.Tests/ReverseFunctionWithMobileSdkTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/ReverseFunctionWithMobileSdkTests.cs
@@ -41,7 +41,6 @@ namespace MyFunctions
 
             // Assert
             Assert.True(context.Response.TryRead(out LambdaTestResponse response));
-            Assert.NotNull(response);
             Assert.True(response.IsSuccessful);
 
             json = await response.ReadAsStringAsync();

--- a/tests/AwsLambdaTestServer.Tests/ReverseFunctionWithMobileSdkTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/ReverseFunctionWithMobileSdkTests.cs
@@ -43,9 +43,8 @@ namespace MyFunctions
             Assert.True(context.Response.TryRead(out LambdaTestResponse response));
             Assert.NotNull(response);
             Assert.True(response.IsSuccessful);
-            Assert.NotNull(response.Content);
 
-            json = Encoding.UTF8.GetString(response.Content);
+            json = await response.ReadAsStringAsync();
             int[] actual = JsonConvert.DeserializeObject<int[]>(json);
 
             Assert.Equal(new[] { 3, 2, 1 }, actual);

--- a/tests/AwsLambdaTestServer.Tests/TestExtensions.cs
+++ b/tests/AwsLambdaTestServer.Tests/TestExtensions.cs
@@ -15,10 +15,10 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
             return await server.EnqueueAsync(json);
         }
 
-        internal static T ReadAs<T>(this LambdaTestResponse response)
+        internal static async Task<T> ReadAsAsync<T>(this LambdaTestResponse response)
             where T : class
         {
-            string json = System.Text.Encoding.UTF8.GetString(response.Content);
+            string json = await response.ReadAsStringAsync();
             return JsonConvert.DeserializeObject<T>(json);
         }
     }


### PR DESCRIPTION
  * Add a built-in extension method for reading the response as a string to make usage more terse for Lambdas that return JSON.
  * Remove asserts from example tests that are testing the library, not the example Lambda.
  * Make a note in the README that the function under test does not have to be .NET Core 3.0 itself.
  * Bump version to 0.3.0.