### PR TITLE
Use EnsureTrailingSlash

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -44,7 +44,7 @@
       <_mapping Include="@(_byProject->'%(Identity)|%(OriginalPath)=%(MappedPath)')" />
     </ItemGroup>
     <PropertyGroup>
-      <_sourceRootMappingFilePath>$([System.IO.Path]::Combine('$(OutputPath)', 'CoverletSourceRootsMapping'))</_sourceRootMappingFilePath>
+      <_sourceRootMappingFilePath>$([MSBuild]::EnsureTrailingSlash('$(OutputPath)'))CoverletSourceRootsMapping</_sourceRootMappingFilePath>
     </PropertyGroup>
     <WriteLinesToFile File="$(_sourceRootMappingFilePath)" Lines="@(_mapping)"
                       Overwrite="true" Encoding="Unicode"


### PR DESCRIPTION
Use `EnsureTrailingSlash()` instead of `Path.Combine()`.
