### PR TITLE
Test updates

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,7 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.0.0" />
     <PackageVersion Include="Moq" Version="4.14.5" />
-    <PackageVersion Include="ReportGenerator" Version="4.6.4" />
+    <PackageVersion Include="ReportGenerator" Version="4.6.5" />
     <PackageVersion Include="Shouldly" Version="3.0.2" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.1.118" />
     <PackageVersion Include="xunit" Version="2.4.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,11 +16,11 @@
     <PackageVersion Include="xunit" Version="2.4.1" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(IsTestProject)' != 'true' ">
+  <ItemGroup Condition=" '$(IsPackable)' == 'true' ">
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="3.0.0" Condition=" '$(TargetFramework)' == 'netcoreapp3.0' " />
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="3.1.0" Condition=" '$(TargetFramework)' == 'netcoreapp3.1' " />
   </ItemGroup>
-  <ItemGroup Condition=" '$(IsTestProject)' == 'true' ">
+  <ItemGroup Condition=" '$(IsPackable)' != 'true' ">
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="3.1.7" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/MathsFunctions.Tests/MathsFunctionTests.cs
+++ b/samples/MathsFunctions.Tests/MathsFunctionTests.cs
@@ -2,10 +2,10 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using System;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using MartinCostello.Testing.AwsLambdaTestServer;
-using Newtonsoft.Json;
 using Xunit;
 
 namespace MathsFunctions
@@ -27,7 +27,7 @@ namespace MathsFunctions
             await server.StartAsync(cancellationTokenSource.Token);
 
             var value = new MathsRequest() { Left = left, Operator = op, Right = right };
-            string json = JsonConvert.SerializeObject(value);
+            string json = JsonSerializer.Serialize(value);
 
             var context = await server.EnqueueAsync(json);
 
@@ -41,7 +41,7 @@ namespace MathsFunctions
             Assert.True(response.IsSuccessful);
 
             json = await response.ReadAsStringAsync();
-            var actual = JsonConvert.DeserializeObject<MathsResponse>(json);
+            var actual = JsonSerializer.Deserialize<MathsResponse>(json);
 
             Assert.Equal(expected, actual.Result);
         }

--- a/samples/MathsFunctions.Tests/MathsFunctionTests.cs
+++ b/samples/MathsFunctions.Tests/MathsFunctionTests.cs
@@ -18,11 +18,12 @@ namespace MathsFunctions
         [InlineData(2, "*", 2, 4)]
         [InlineData(9, "/", 3, 3)]
         [InlineData(7, "%", 2, 1)]
+        [InlineData(3, "^", 3, 27)]
         public static async Task Function_Computes_Results(double left, string op, double right, double expected)
         {
             // Arrange
             using var server = new LambdaTestServer();
-            using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(0.2));
+            using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(1));
 
             await server.StartAsync(cancellationTokenSource.Token);
 

--- a/samples/MathsFunctions/MathsFunction.cs
+++ b/samples/MathsFunctions/MathsFunction.cs
@@ -34,6 +34,7 @@ namespace MathsFunctions
                 "*" => request.Left * request.Right,
                 "/" => request.Left / request.Right,
                 "%" => request.Left % request.Right,
+                "^" => Math.Pow(request.Left, request.Right),
                 _ => throw new NotSupportedException($"The '{request.Operator}' operator is not supported."),
             };
 

--- a/samples/MathsFunctions/MathsFunctions.csproj
+++ b/samples/MathsFunctions/MathsFunctions.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <IsPackable>false</IsPackable>
     <NoWarn>$(NoWarn);CA2000;CA2007;SA1600</NoWarn>
     <OutputType>Library</OutputType>
     <RootNamespace>MathsFunctions</RootNamespace>

--- a/tests/AwsLambdaTestServer.Tests/Examples.cs
+++ b/tests/AwsLambdaTestServer.Tests/Examples.cs
@@ -2,9 +2,9 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using System;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 using Shouldly;
 using Xunit;
 
@@ -34,7 +34,7 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
                 Values = new[] { 1, 2, 3 }, // The function returns the sum of the specified numbers
             };
 
-            string requestJson = JsonConvert.SerializeObject(value);
+            string requestJson = JsonSerializer.Serialize(value);
 
             // Queue the request with the server to invoke the Lambda function and
             // store the ChannelReader into a variable to use to read the response.
@@ -64,7 +64,7 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
             response.Content.ShouldNotBeEmpty("The Lambda function did not return any content.");
 
             string responseJson = await response.ReadAsStringAsync();
-            var actual = JsonConvert.DeserializeObject<MyResponse>(responseJson);
+            var actual = JsonSerializer.Deserialize<MyResponse>(responseJson);
 
             actual.Sum.ShouldBe(6, "The Lambda function returned an incorrect response.");
         }

--- a/tests/AwsLambdaTestServer.Tests/LambdaTestServerTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/LambdaTestServerTests.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Text;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Amazon.Lambda.RuntimeSupport;
@@ -15,7 +16,6 @@ using MartinCostello.Logging.XUnit;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
 using Shouldly;
 using Xunit;
 using Xunit.Abstractions;
@@ -499,7 +499,7 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
                     ["RemainingTime"] = request.LambdaContext.RemainingTime.ToString("G", CultureInfo.InvariantCulture),
                 };
 
-                string json = JsonConvert.SerializeObject(context);
+                string json = JsonSerializer.Serialize(context);
 
                 var stream = new MemoryStream();
                 using var writer = new StreamWriter(stream, leaveOpen: true);

--- a/tests/AwsLambdaTestServer.Tests/LambdaTestServerTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/LambdaTestServerTests.cs
@@ -483,7 +483,7 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
 
         private class CustomHandler
         {
-            public virtual async Task<InvocationResponse> InvokeAsync(InvocationRequest request)
+            public virtual Task<InvocationResponse> InvokeAsync(InvocationRequest request)
             {
                 var context = new Dictionary<string, string>()
                 {
@@ -499,14 +499,11 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
                     ["RemainingTime"] = request.LambdaContext.RemainingTime.ToString("G", CultureInfo.InvariantCulture),
                 };
 
-                string json = JsonSerializer.Serialize(context);
+                byte[] json = JsonSerializer.SerializeToUtf8Bytes(context);
 
-                var stream = new MemoryStream();
-                using var writer = new StreamWriter(stream, leaveOpen: true);
+                var stream = new MemoryStream(json);
 
-                await writer.WriteAsync(json);
-
-                return new InvocationResponse(stream, true);
+                return Task.FromResult(new InvocationResponse(stream, true));
             }
         }
 

--- a/tests/AwsLambdaTestServer.Tests/LambdaTestServerTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/LambdaTestServerTests.cs
@@ -359,7 +359,7 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
                 response.IsSuccessful.ShouldBeTrue();
                 response.Content.ShouldNotBeNull();
 
-                var deserialized = await response.ReadAsAsync<MyResponse>();
+                var deserialized = response.ReadAs<MyResponse>();
                 deserialized.Sum.ShouldBe(expected);
             }
         }
@@ -451,7 +451,7 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
             response.IsSuccessful.ShouldBeTrue();
             response.Content.ShouldNotBeNull();
 
-            var lambdaContext = await response.ReadAsAsync<IDictionary<string, string>>();
+            var lambdaContext = response.ReadAs<IDictionary<string, string>>();
             lambdaContext.ShouldContainKeyAndValue("AwsRequestId", request.AwsRequestId);
             lambdaContext.ShouldContainKeyAndValue("ClientContext", "my-app");
             lambdaContext.ShouldContainKeyAndValue("FunctionName", options.FunctionName);

--- a/tests/AwsLambdaTestServer.Tests/ParallelismTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/ParallelismTests.cs
@@ -87,7 +87,7 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
 
                     var result = await context.Response.ReadAsync();
 
-                    var response = await result.ReadAsAsync<int[]>();
+                    var response = result.ReadAs<int[]>();
 
                     actual += response[0];
                 }

--- a/tests/AwsLambdaTestServer.Tests/ReverseFunctionTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/ReverseFunctionTests.cs
@@ -22,7 +22,7 @@ namespace MyFunctions
             await server.StartAsync(cancellationTokenSource.Token);
 
             int[] value = new[] { 1, 2, 3 };
-            string json = JsonSerializer.Serialize(value);
+            byte[] json = JsonSerializer.SerializeToUtf8Bytes(value);
 
             LambdaTestContext context = await server.EnqueueAsync(json);
 
@@ -35,8 +35,7 @@ namespace MyFunctions
             Assert.True(context.Response.TryRead(out LambdaTestResponse response));
             Assert.True(response.IsSuccessful);
 
-            json = await response.ReadAsStringAsync();
-            int[] actual = JsonSerializer.Deserialize<int[]>(json);
+            int[] actual = JsonSerializer.Deserialize<int[]>(response.Content);
 
             Assert.Equal(new[] { 3, 2, 1 }, actual);
         }

--- a/tests/AwsLambdaTestServer.Tests/ReverseFunctionTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/ReverseFunctionTests.cs
@@ -2,10 +2,10 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using System;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using MartinCostello.Testing.AwsLambdaTestServer;
-using Newtonsoft.Json;
 using Xunit;
 
 namespace MyFunctions
@@ -22,7 +22,7 @@ namespace MyFunctions
             await server.StartAsync(cancellationTokenSource.Token);
 
             int[] value = new[] { 1, 2, 3 };
-            string json = JsonConvert.SerializeObject(value);
+            string json = JsonSerializer.Serialize(value);
 
             LambdaTestContext context = await server.EnqueueAsync(json);
 
@@ -36,7 +36,7 @@ namespace MyFunctions
             Assert.True(response.IsSuccessful);
 
             json = await response.ReadAsStringAsync();
-            int[] actual = JsonConvert.DeserializeObject<int[]>(json);
+            int[] actual = JsonSerializer.Deserialize<int[]>(json);
 
             Assert.Equal(new[] { 3, 2, 1 }, actual);
         }

--- a/tests/AwsLambdaTestServer.Tests/ReverseFunctionWithCustomOptionsTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/ReverseFunctionWithCustomOptionsTests.cs
@@ -29,7 +29,7 @@ namespace MyFunctions
             await server.StartAsync(cancellationTokenSource.Token);
 
             int[] value = new[] { 1, 2, 3 };
-            string json = JsonSerializer.Serialize(value);
+            byte[] json = JsonSerializer.SerializeToUtf8Bytes(value);
 
             LambdaTestContext context = await server.EnqueueAsync(json);
 
@@ -42,8 +42,7 @@ namespace MyFunctions
             Assert.True(context.Response.TryRead(out LambdaTestResponse response));
             Assert.True(response.IsSuccessful);
 
-            json = await response.ReadAsStringAsync();
-            int[] actual = JsonSerializer.Deserialize<int[]>(json);
+            int[] actual = JsonSerializer.Deserialize<int[]>(response.Content);
 
             Assert.Equal(new[] { 3, 2, 1 }, actual);
         }

--- a/tests/AwsLambdaTestServer.Tests/ReverseFunctionWithCustomOptionsTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/ReverseFunctionWithCustomOptionsTests.cs
@@ -2,10 +2,10 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using System;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using MartinCostello.Testing.AwsLambdaTestServer;
-using Newtonsoft.Json;
 using Xunit;
 
 namespace MyFunctions
@@ -29,7 +29,7 @@ namespace MyFunctions
             await server.StartAsync(cancellationTokenSource.Token);
 
             int[] value = new[] { 1, 2, 3 };
-            string json = JsonConvert.SerializeObject(value);
+            string json = JsonSerializer.Serialize(value);
 
             LambdaTestContext context = await server.EnqueueAsync(json);
 
@@ -43,7 +43,7 @@ namespace MyFunctions
             Assert.True(response.IsSuccessful);
 
             json = await response.ReadAsStringAsync();
-            int[] actual = JsonConvert.DeserializeObject<int[]>(json);
+            int[] actual = JsonSerializer.Deserialize<int[]>(json);
 
             Assert.Equal(new[] { 3, 2, 1 }, actual);
         }

--- a/tests/AwsLambdaTestServer.Tests/ReverseFunctionWithLoggingTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/ReverseFunctionWithLoggingTests.cs
@@ -36,7 +36,7 @@ namespace MyFunctions
             await server.StartAsync(cancellationTokenSource.Token);
 
             int[] value = new[] { 1, 2, 3 };
-            string json = JsonSerializer.Serialize(value);
+            byte[] json = JsonSerializer.SerializeToUtf8Bytes(value);
 
             LambdaTestContext context = await server.EnqueueAsync(json);
 
@@ -49,8 +49,7 @@ namespace MyFunctions
             Assert.True(context.Response.TryRead(out LambdaTestResponse response));
             Assert.True(response.IsSuccessful);
 
-            json = await response.ReadAsStringAsync();
-            int[] actual = JsonSerializer.Deserialize<int[]>(json);
+            int[] actual = JsonSerializer.Deserialize<int[]>(response.Content);
 
             Assert.Equal(new[] { 3, 2, 1 }, actual);
         }

--- a/tests/AwsLambdaTestServer.Tests/ReverseFunctionWithLoggingTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/ReverseFunctionWithLoggingTests.cs
@@ -2,13 +2,13 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using System;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using MartinCostello.Logging.XUnit;
 using MartinCostello.Testing.AwsLambdaTestServer;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -36,7 +36,7 @@ namespace MyFunctions
             await server.StartAsync(cancellationTokenSource.Token);
 
             int[] value = new[] { 1, 2, 3 };
-            string json = JsonConvert.SerializeObject(value);
+            string json = JsonSerializer.Serialize(value);
 
             LambdaTestContext context = await server.EnqueueAsync(json);
 
@@ -50,7 +50,7 @@ namespace MyFunctions
             Assert.True(response.IsSuccessful);
 
             json = await response.ReadAsStringAsync();
-            int[] actual = JsonConvert.DeserializeObject<int[]>(json);
+            int[] actual = JsonSerializer.Deserialize<int[]>(json);
 
             Assert.Equal(new[] { 3, 2, 1 }, actual);
         }

--- a/tests/AwsLambdaTestServer.Tests/ReverseFunctionWithMobileSdkTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/ReverseFunctionWithMobileSdkTests.cs
@@ -3,10 +3,10 @@
 
 using System;
 using System.Text;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using MartinCostello.Testing.AwsLambdaTestServer;
-using Newtonsoft.Json;
 using Xunit;
 
 namespace MyFunctions
@@ -23,7 +23,7 @@ namespace MyFunctions
             await server.StartAsync(cancellationTokenSource.Token);
 
             int[] value = new[] { 1, 2, 3 };
-            string json = JsonConvert.SerializeObject(value);
+            string json = JsonSerializer.Serialize(value);
             byte[] content = Encoding.UTF8.GetBytes(json);
 
             var request = new LambdaTestRequest(content)
@@ -44,7 +44,7 @@ namespace MyFunctions
             Assert.True(response.IsSuccessful);
 
             json = await response.ReadAsStringAsync();
-            int[] actual = JsonConvert.DeserializeObject<int[]>(json);
+            int[] actual = JsonSerializer.Deserialize<int[]>(json);
 
             Assert.Equal(new[] { 3, 2, 1 }, actual);
         }

--- a/tests/AwsLambdaTestServer.Tests/TestExtensions.cs
+++ b/tests/AwsLambdaTestServer.Tests/TestExtensions.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Martin Costello, 2019. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System.Text.Json;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 
 namespace MartinCostello.Testing.AwsLambdaTestServer
 {
@@ -11,7 +11,7 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
         internal static async Task<LambdaTestContext> EnqueueAsync<T>(this LambdaTestServer server, T value)
             where T : class
         {
-            string json = JsonConvert.SerializeObject(value);
+            string json = JsonSerializer.Serialize(value);
             return await server.EnqueueAsync(json);
         }
 
@@ -19,7 +19,7 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
             where T : class
         {
             string json = await response.ReadAsStringAsync();
-            return JsonConvert.DeserializeObject<T>(json);
+            return JsonSerializer.Deserialize<T>(json);
         }
     }
 }

--- a/tests/AwsLambdaTestServer.Tests/TestExtensions.cs
+++ b/tests/AwsLambdaTestServer.Tests/TestExtensions.cs
@@ -11,15 +11,14 @@ namespace MartinCostello.Testing.AwsLambdaTestServer
         internal static async Task<LambdaTestContext> EnqueueAsync<T>(this LambdaTestServer server, T value)
             where T : class
         {
-            string json = JsonSerializer.Serialize(value);
+            byte[] json = JsonSerializer.SerializeToUtf8Bytes(value);
             return await server.EnqueueAsync(json);
         }
 
-        internal static async Task<T> ReadAsAsync<T>(this LambdaTestResponse response)
+        internal static T ReadAs<T>(this LambdaTestResponse response)
             where T : class
         {
-            string json = await response.ReadAsStringAsync();
-            return JsonSerializer.Deserialize<T>(json);
+            return JsonSerializer.Deserialize<T>(response.Content);
         }
     }
 }


### PR DESCRIPTION
  * Use System.Text.Json instead of Newtonsoft.Json in various places in the tests and simplify them.
  * Wait for up to 1 second for the sample function test to run and return a result.
