### PR TITLE
Add test timeout

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -132,7 +132,7 @@ function DotNetTest {
         $additionalArgs += "GitHubActions;report-warnings=false"
     }
 
-    & $dotnet test $Project --output $OutputPath --configuration $Configuration $additionalArgs
+    & $dotnet test $Project --output $OutputPath --configuration $Configuration $additionalArgs -- RunConfiguration.TestSessionTimeout=300000
 
     $dotNetTestExitCode = $LASTEXITCODE
 


### PR DESCRIPTION
Fail the test run if it takes longer than 5 minutes.

This should help with eventually getting to the bottom of what's making the tests hang and then timeout after 6 hours in CI sometimes.
