### PR TITLE
Bump version to 0.7.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -39,7 +39,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <UseSharedCompilation>false</UseSharedCompilation>
     <AssemblyVersion>0.7.0.0</AssemblyVersion>
-    <VersionPrefix>0.7.0</VersionPrefix>
+    <VersionPrefix>0.7.1</VersionPrefix>
     <VersionSuffix Condition=" '$(VersionSuffix)' == '' AND '$(GITHUB_ACTIONS)' != '' ">preview.$(GITHUB_RUN_NUMBER)</VersionSuffix>
     <VersionPrefix Condition=" $(GITHUB_REF.StartsWith(`refs/tags/v`)) ">$(GITHUB_REF.Replace('refs/tags/v', ''))</VersionPrefix>
     <VersionSuffix Condition=" $(GITHUB_REF.StartsWith(`refs/tags/v`)) "></VersionSuffix>

--- a/src/AwsLambdaTestServer/MartinCostello.Testing.AwsLambdaTestServer.csproj
+++ b/src/AwsLambdaTestServer/MartinCostello.Testing.AwsLambdaTestServer.csproj
@@ -2,18 +2,15 @@
   <PropertyGroup>
     <AssemblyTitle>Test server for AWS Lambda</AssemblyTitle>
     <Description>Provides an in-memory test server for testing AWS Lambda functions.</Description>
+    <EnablePackageValidation>true</EnablePackageValidation>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <OutputType>Library</OutputType>
     <PackageId>MartinCostello.Testing.AwsLambdaTestServer</PackageId>
+    <PackageValidationBaselineVersion>0.7.0</PackageValidationBaselineVersion>
     <RootNamespace>MartinCostello.Testing.AwsLambdaTestServer</RootNamespace>
     <Summary>$(Description)</Summary>
     <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <Title>AWS Lambda Test Server</Title>
-    <!--
-    TODO Re-enable once 0.7.0 is shipped.
-    <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>0.7.0</PackageValidationBaselineVersion>
-    -->
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.TestHost" />


### PR DESCRIPTION
- Bump version to 0.7.1 for the next release.
- Re-enable package baseline validation.
