### PR TITLE
 Remove redundant suppression

### DIFF
--- a/samples/MinimalApi/Program.cs
+++ b/samples/MinimalApi/Program.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Martin Costello, 2019. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
-#pragma warning disable CA1852
-
 using System.Security.Cryptography;
 using System.Text;
 using MinimalApi;


### PR DESCRIPTION
Remove now-redundant suppression for false-positive code analysis warning.
