### PR TITLE
Update to .NET 8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
       with:
-        file: ./artifacts/coverage/coverage.net7.0.cobertura.xml
+        file: ./artifacts/coverage/coverage.net8.0.cobertura.xml
         flags: ${{ matrix.os_name }}
 
     - name: Publish artifacts
@@ -95,7 +95,7 @@ jobs:
       uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
       with:
         name: packages-${{ matrix.os_name }}
-        path: ./artifacts/packages
+        path: ./artifacts/package/release
         if-no-files-found: error
 
   validate-packages:

--- a/.vsconfig
+++ b/.vsconfig
@@ -3,7 +3,7 @@
   "components": [
     "Microsoft.VisualStudio.Component.CoreEditor",
     "Microsoft.VisualStudio.Workload.CoreEditor",
-    "Microsoft.NetCore.Component.Runtime.7.0",
+    "Microsoft.NetCore.Component.Runtime.8.0",
     "Microsoft.NetCore.Component.SDK",
     "Microsoft.VisualStudio.Component.Roslyn.Compiler",
     "Microsoft.VisualStudio.Component.Roslyn.LanguageServices"

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,6 +26,10 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <NeutralLanguage>en-US</NeutralLanguage>
     <NoWarn>$(NoWarn);CA1848</NoWarn>
+    <!--
+      TODO Remove NU5104 once .NET 8 reaches 8.0.0.
+    -->
+    <NoWarn>$(NoWarn);NU5104</NoWarn>
     <NoWarn Condition=" '$(GenerateDocumentationFile)' != 'true' ">$(NoWarn);SA0001</NoWarn>
     <Nullable>enable</Nullable>
     <PackageIcon></PackageIcon>
@@ -42,6 +46,7 @@
     <SignAssembly>true</SignAssembly>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <UseArtifactsOutput>true</UseArtifactsOutput>
     <UseSharedCompilation>false</UseSharedCompilation>
     <AssemblyVersion>0.7.0.0</AssemblyVersion>
     <VersionPrefix>0.7.2</VersionPrefix>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -52,8 +52,8 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <UseArtifactsOutput>true</UseArtifactsOutput>
     <UseSharedCompilation>false</UseSharedCompilation>
-    <AssemblyVersion>0.7.0.0</AssemblyVersion>
-    <VersionPrefix>0.7.2</VersionPrefix>
+    <AssemblyVersion>0.8.0.0</AssemblyVersion>
+    <VersionPrefix>0.8.0</VersionPrefix>
     <VersionSuffix Condition=" '$(VersionSuffix)' == '' AND '$(GITHUB_ACTIONS)' != '' ">preview.$(GITHUB_RUN_NUMBER)</VersionSuffix>
     <VersionPrefix Condition=" $(GITHUB_REF.StartsWith(`refs/tags/v`)) ">$(GITHUB_REF.Replace('refs/tags/v', ''))</VersionPrefix>
     <VersionSuffix Condition=" $(GITHUB_REF.StartsWith(`refs/tags/v`)) "></VersionSuffix>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -30,6 +30,10 @@
       TODO Remove NU5104 once .NET 8 reaches 8.0.0.
     -->
     <NoWarn>$(NoWarn);NU5104</NoWarn>
+    <!--
+      HACK Workaround for https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3687
+    -->
+    <NoWarn>$(NoWarn);SA1010</NoWarn>
     <NoWarn Condition=" '$(GenerateDocumentationFile)' != 'true' ">$(NoWarn);SA0001</NoWarn>
     <Nullable>enable</Nullable>
     <PackageIcon></PackageIcon>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -27,10 +27,6 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <NoWarn>$(NoWarn);CA1848</NoWarn>
     <!--
-      TODO Remove NU5104 once .NET 8 reaches 8.0.0.
-    -->
-    <NoWarn>$(NoWarn);NU5104</NoWarn>
-    <!--
       HACK Workaround for https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3687
     -->
     <NoWarn>$(NoWarn);SA1010</NoWarn>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -22,7 +22,7 @@
     <ReportGeneratorOutputMarkdown Condition=" '$(ReportGeneratorOutputMarkdown)' == '' AND '$(GITHUB_SHA)' != '' ">true</ReportGeneratorOutputMarkdown>
     <ReportGeneratorReportTypes>HTML</ReportGeneratorReportTypes>
     <ReportGeneratorReportTypes Condition=" '$(ReportGeneratorOutputMarkdown)' == 'true' ">$(ReportGeneratorReportTypes);MarkdownSummaryGitHub</ReportGeneratorReportTypes>
-    <ReportGeneratorTargetDirectory>$([System.IO.Path]::Combine($(OutputPath), 'coverage'))</ReportGeneratorTargetDirectory>
+    <ReportGeneratorTargetDirectory>$([System.IO.Path]::Combine($(ArtifactsPath), 'coverage'))</ReportGeneratorTargetDirectory>
     <_MarkdownSummaryPrefix>&lt;details&gt;&lt;summary&gt;:chart_with_upwards_trend: &lt;b&gt;$(AssemblyName) Code Coverage report&lt;/b&gt;&lt;/summary&gt;</_MarkdownSummaryPrefix>
     <_MarkdownSummarySuffix>&lt;/details&gt;</_MarkdownSummarySuffix>
   </PropertyGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,7 +9,6 @@
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageVersion Include="NSubstitute" Version="5.1.0" />
     <PackageVersion Include="ReportGenerator" Version="5.1.26" />
     <PackageVersion Include="Shouldly" Version="4.2.1" />
@@ -22,13 +21,13 @@
   <ItemGroup Condition=" '$(IsPackable)' == 'true' ">
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="6.0.0" Condition=" '$(TargetFramework)' == 'net6.0' " />
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="7.0.0" Condition=" '$(TargetFramework)' == 'net7.0' " />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.0-preview.7.23375.9" Condition=" '$(TargetFramework)' == 'net8.0' " />
   </ItemGroup>
   <ItemGroup Condition=" '$(IsPackable)' != 'true' ">
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="7.0.13" Condition=" '$(TargetFramework)' == 'net7.0' " />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.0-preview.7.23375.9" Condition=" '$(TargetFramework)' == 'net8.0' " />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup Condition=" '$(IsTestProject)' == 'true' ">

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,10 +21,10 @@
   <ItemGroup Condition=" '$(IsPackable)' == 'true' ">
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="6.0.0" Condition=" '$(TargetFramework)' == 'net6.0' " />
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="7.0.0" Condition=" '$(TargetFramework)' == 'net7.0' " />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.0-rc.1.23421.29" Condition=" '$(TargetFramework)' == 'net8.0' " />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.0-rc.2.23480.2" Condition=" '$(TargetFramework)' == 'net8.0' " />
   </ItemGroup>
   <ItemGroup Condition=" '$(IsPackable)' != 'true' ">
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.0-rc.1.23421.29" Condition=" '$(TargetFramework)' == 'net8.0' " />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.0-rc.2.23480.2" Condition=" '$(TargetFramework)' == 'net8.0' " />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="All" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,10 +21,10 @@
   <ItemGroup Condition=" '$(IsPackable)' == 'true' ">
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="6.0.0" Condition=" '$(TargetFramework)' == 'net6.0' " />
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="7.0.0" Condition=" '$(TargetFramework)' == 'net7.0' " />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.0-rc.2.23480.2" Condition=" '$(TargetFramework)' == 'net8.0' " />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.0" Condition=" '$(TargetFramework)' == 'net8.0' " />
   </ItemGroup>
   <ItemGroup Condition=" '$(IsPackable)' != 'true' ">
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.0-rc.2.23480.2" Condition=" '$(TargetFramework)' == 'net8.0' " />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.0" Condition=" '$(TargetFramework)' == 'net8.0' " />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="All" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,10 +21,10 @@
   <ItemGroup Condition=" '$(IsPackable)' == 'true' ">
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="6.0.0" Condition=" '$(TargetFramework)' == 'net6.0' " />
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="7.0.0" Condition=" '$(TargetFramework)' == 'net7.0' " />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.0-preview.7.23375.9" Condition=" '$(TargetFramework)' == 'net8.0' " />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.0-rc.1.23421.29" Condition=" '$(TargetFramework)' == 'net8.0' " />
   </ItemGroup>
   <ItemGroup Condition=" '$(IsPackable)' != 'true' ">
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.0-preview.7.23375.9" Condition=" '$(TargetFramework)' == 'net8.0' " />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.0-rc.1.23421.29" Condition=" '$(TargetFramework)' == 'net8.0' " />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="All" />

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ The key parts to call out here are:
   1. Once the function processing completes after the `CancellationToken` is signalled, the channel reader is read to obtain the `LambdaTestResponse` for the request that was enqueued.
   1. Once this is returned from the channel reader, the response is checked for success using `IsSuccessful` and then the `Content` (which is a `byte[]`) is deserialized into the expected response to be asserted on. Again, you could make your own extensions to deserialize the response content into `string` or objects from JSON.
 
-The library itself targets `net6.0` and `net7.0` so requires your test project to target at least .NET 6.
+The library itself targets `net6.0`, `net7.0` and `net8.0` so requires your test project to target at least .NET 6.
 
 #### Sequence Diagram
 

--- a/build.ps1
+++ b/build.ps1
@@ -1,7 +1,5 @@
 #! /usr/bin/env pwsh
 param(
-    [Parameter(Mandatory = $false)][string] $Configuration = "Release",
-    [Parameter(Mandatory = $false)][string] $OutputPath = "",
     [Parameter(Mandatory = $false)][switch] $SkipTests
 )
 
@@ -24,10 +22,6 @@ $testProjects = @(
 )
 
 $dotnetVersion = (Get-Content $sdkFile | Out-String | ConvertFrom-Json).sdk.version
-
-if ($OutputPath -eq "") {
-    $OutputPath = Join-Path $PSScriptRoot "artifacts"
-}
 
 $installDotNetSdk = $false;
 
@@ -86,9 +80,7 @@ if ($installDotNetSdk -eq $true) {
 function DotNetPack {
     param([string]$Project)
 
-    $PackageOutputPath = (Join-Path $OutputPath "packages")
-
-    & $dotnet pack $Project --output $PackageOutputPath --configuration $Configuration --include-symbols --include-source
+    & $dotnet pack $Project --include-symbols --include-source
 
     if ($LASTEXITCODE -ne 0) {
         throw "dotnet pack failed with exit code $LASTEXITCODE"
@@ -105,7 +97,7 @@ function DotNetTest {
         $additionalArgs += "GitHubActions;report-warnings=false"
     }
 
-    & $dotnet test $Project --output $OutputPath --configuration $Configuration $additionalArgs -- RunConfiguration.TestSessionTimeout=300000
+    & $dotnet test $Project --configuration "Release" $additionalArgs -- RunConfiguration.TestSessionTimeout=300000
 
     if ($LASTEXITCODE -ne 0) {
         throw "dotnet test failed with exit code $LASTEXITCODE"

--- a/build.ps1
+++ b/build.ps1
@@ -80,7 +80,7 @@ if ($installDotNetSdk -eq $true) {
 function DotNetPack {
     param([string]$Project)
 
-    & $dotnet pack $Project --include-symbols --include-source
+    & $dotnet pack $Project --include-symbols --include-source --tl
 
     if ($LASTEXITCODE -ne 0) {
         throw "dotnet pack failed with exit code $LASTEXITCODE"
@@ -97,7 +97,7 @@ function DotNetTest {
         $additionalArgs += "GitHubActions;report-warnings=false"
     }
 
-    & $dotnet test $Project --configuration "Release" $additionalArgs -- RunConfiguration.TestSessionTimeout=300000
+    & $dotnet test $Project --configuration "Release" --tl $additionalArgs -- RunConfiguration.TestSessionTimeout=300000
 
     if ($LASTEXITCODE -ne 0) {
         throw "dotnet test failed with exit code $LASTEXITCODE"

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100-rc.1.23455.8",
+    "version": "8.0.100-rc.1.23463.5",
     "allowPrerelease": false
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100-preview.7.23376.3",
+    "version": "8.0.100-rc.1.23455.8",
     "allowPrerelease": false
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100-rc.1.23463.5",
+    "version": "8.0.100-rc.2.23502.2",
     "allowPrerelease": false
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100-rc.2.23502.2",
+    "version": "8.0.100",
     "allowPrerelease": false
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.403",
+    "version": "8.0.100-preview.7.23376.3",
     "allowPrerelease": false
   }
 }

--- a/samples/MathsFunctions.Tests/MathsFunctions.Tests.csproj
+++ b/samples/MathsFunctions.Tests/MathsFunctions.Tests.csproj
@@ -4,7 +4,7 @@
     <IsTestProject>true</IsTestProject>
     <NoWarn>$(NoWarn);CA1062;CA1707;CA2007;CA2234;SA1600</NoWarn>
     <RootNamespace>MathsFunctions</RootNamespace>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />

--- a/samples/MathsFunctions/MathsFunction.cs
+++ b/samples/MathsFunctions/MathsFunction.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Martin Costello, 2019. All rights reserved.
+﻿// Copyright (c) Martin Costello, 2019. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using Amazon.Lambda.RuntimeSupport;

--- a/samples/MathsFunctions/MathsFunctions.csproj
+++ b/samples/MathsFunctions/MathsFunctions.csproj
@@ -4,7 +4,7 @@
     <NoWarn>$(NoWarn);CA2000;CA2007;SA1600</NoWarn>
     <OutputType>Library</OutputType>
     <RootNamespace>MathsFunctions</RootNamespace>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.RuntimeSupport" />

--- a/samples/MinimalApi.Tests/ApiTests.cs
+++ b/samples/MinimalApi.Tests/ApiTests.cs
@@ -98,9 +98,11 @@ public sealed class ApiTests : IAsyncLifetime, IDisposable
         hash.Hash.ShouldBe("XXE/IcKhlw/yjLTH7cCWPSr7JfOw5LuYXeBuE5skNfA=");
     }
 
-    [Fact(Timeout = 5_000, Skip = "Depends on aws/aws-lambda-dotnet#1595.")]
+    [SkippableFact(Timeout = 5_000, Skip = "Depends on aws/aws-lambda-dotnet#1595.")]
     public async Task Memory_Limit_Is_Not_Enforced()
     {
+        Skip.If(OperatingSystem.IsMacOS(), "Changing the GC memory limits is not supported on macOS.");
+
         // Arrange
         var options = new JsonSerializerOptions(JsonSerializerDefaults.Web);
 

--- a/samples/MinimalApi.Tests/ApiTests.cs
+++ b/samples/MinimalApi.Tests/ApiTests.cs
@@ -117,7 +117,7 @@ public sealed class ApiTests : IAsyncLifetime, IDisposable
 
                 if (!cts.IsCancellationRequested)
                 {
-                    cts.Cancel();
+                    await cts.CancelAsync();
                 }
             },
             cts.Token);

--- a/samples/MinimalApi.Tests/ApiTests.cs
+++ b/samples/MinimalApi.Tests/ApiTests.cs
@@ -98,68 +98,6 @@ public sealed class ApiTests : IAsyncLifetime, IDisposable
         hash.Hash.ShouldBe("XXE/IcKhlw/yjLTH7cCWPSr7JfOw5LuYXeBuE5skNfA=");
     }
 
-    [SkippableFact(Timeout = 5_000, Skip = "Depends on aws/aws-lambda-dotnet#1595.")]
-    public async Task Memory_Limit_Is_Not_Enforced()
-    {
-        Skip.If(OperatingSystem.IsMacOS(), "Changing the GC memory limits is not supported on macOS.");
-
-        // Arrange
-        var options = new JsonSerializerOptions(JsonSerializerDefaults.Web);
-
-        var request = new APIGatewayProxyRequest()
-        {
-            HttpMethod = HttpMethods.Get,
-            Path = "/memory-limit",
-        };
-
-        // Arrange
-        string json = JsonSerializer.Serialize(request, options);
-
-        LambdaTestContext context = await _server.EnqueueAsync(json);
-
-        using var cts = GetCancellationTokenSourceForResponseAvailable(context);
-
-        // Act
-        _ = Task.Run(
-            () =>
-            {
-                try
-                {
-                    typeof(HashRequest).Assembly.EntryPoint!.Invoke(null, new[] { Array.Empty<string>() });
-                }
-                catch (Exception ex) when (LambdaServerWasShutDown(ex))
-                {
-                    // The Lambda runtime server was shut down
-                }
-            },
-            cts.Token);
-
-        // Assert
-        await context.Response.WaitToReadAsync(cts.IsCancellationRequested ? default : cts.Token);
-
-        context.Response.TryRead(out LambdaTestResponse? response).ShouldBeTrue();
-        response.IsSuccessful.ShouldBeTrue($"Failed to process request: {await response.ReadAsStringAsync()}");
-        response.Duration.ShouldBeInRange(TimeSpan.Zero, TimeSpan.FromSeconds(2));
-        response.Content.ShouldNotBeEmpty();
-
-        // Assert
-        var actual = JsonSerializer.Deserialize<APIGatewayProxyResponse>(response.Content, options);
-
-        actual.ShouldNotBeNull();
-
-        actual.ShouldNotBeNull();
-        actual.StatusCode.ShouldBe(StatusCodes.Status200OK);
-        actual.MultiValueHeaders.ShouldContainKey("Content-Type");
-        actual.MultiValueHeaders["Content-Type"].ShouldBe(["application/json; charset=utf-8"]);
-
-        using var memoryInfo = JsonSerializer.Deserialize<JsonDocument>(actual.Body, options);
-
-        memoryInfo.ShouldNotBeNull();
-        memoryInfo.RootElement.TryGetProperty("totalAvailableMemoryBytes", out var property).ShouldBeTrue();
-        property.TryGetInt64(out var value).ShouldBeTrue();
-        value.ShouldBeGreaterThan(128 * 1024 * 1024);
-    }
-
     private static CancellationTokenSource GetCancellationTokenSourceForResponseAvailable(
         LambdaTestContext context,
         TimeSpan? timeout = null)

--- a/samples/MinimalApi.Tests/HttpLambdaTestServer.cs
+++ b/samples/MinimalApi.Tests/HttpLambdaTestServer.cs
@@ -16,11 +16,6 @@ internal sealed class HttpLambdaTestServer : LambdaTestServer, IAsyncLifetime, I
     private bool _disposed;
     private IWebHost? _webHost;
 
-    public HttpLambdaTestServer()
-        : base(new LambdaTestServerOptions() { FunctionMemorySize = 128, DisableMemoryLimitCheck = true })
-    {
-    }
-
     public ITestOutputHelper? OutputHelper { get; set; }
 
     public async Task DisposeAsync()

--- a/samples/MinimalApi.Tests/HttpLambdaTestServer.cs
+++ b/samples/MinimalApi.Tests/HttpLambdaTestServer.cs
@@ -16,6 +16,11 @@ internal sealed class HttpLambdaTestServer : LambdaTestServer, IAsyncLifetime, I
     private bool _disposed;
     private IWebHost? _webHost;
 
+    public HttpLambdaTestServer()
+        : base(new LambdaTestServerOptions() { FunctionMemorySize = 128, DisableMemoryLimitCheck = true })
+    {
+    }
+
     public ITestOutputHelper? OutputHelper { get; set; }
 
     public async Task DisposeAsync()

--- a/samples/MinimalApi.Tests/MinimalApi.Tests.csproj
+++ b/samples/MinimalApi.Tests/MinimalApi.Tests.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="xRetry" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Xunit.SkippableFact" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MinimalApi\MinimalApi.csproj" />

--- a/samples/MinimalApi.Tests/MinimalApi.Tests.csproj
+++ b/samples/MinimalApi.Tests/MinimalApi.Tests.csproj
@@ -4,7 +4,7 @@
     <IsTestProject>true</IsTestProject>
     <NoWarn>$(NoWarn);CA1062;CA1707;CA1861;CA2007;CA2234;SA1600</NoWarn>
     <RootNamespace>MinimalApi</RootNamespace>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />

--- a/samples/MinimalApi.Tests/MinimalApi.Tests.csproj
+++ b/samples/MinimalApi.Tests/MinimalApi.Tests.csproj
@@ -16,7 +16,6 @@
     <PackageReference Include="xRetry" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
-    <PackageReference Include="Xunit.SkippableFact" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MinimalApi\MinimalApi.csproj" />

--- a/samples/MinimalApi/MinimalApi.csproj
+++ b/samples/MinimalApi/MinimalApi.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <NoWarn>$(NoWarn);CA1050;CA1812;CA2007;CA5350;CA5351;SA1600</NoWarn>
     <RootNamespace>MinimalApi</RootNamespace>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.AspNetCoreServer.Hosting" />

--- a/samples/MinimalApi/Program.cs
+++ b/samples/MinimalApi/Program.cs
@@ -62,7 +62,7 @@ app.MapPost("/hash", async (HttpRequest httpRequest) =>
         "SHA256" => SHA256.HashData(buffer),
         "SHA384" => SHA384.HashData(buffer),
         "SHA512" => SHA512.HashData(buffer),
-        _ => Array.Empty<byte>(),
+        _ => [],
     };
 
     if (hash.Length == 0)

--- a/samples/MinimalApi/Program.cs
+++ b/samples/MinimalApi/Program.cs
@@ -80,12 +80,4 @@ app.MapPost("/hash", async (HttpRequest httpRequest) =>
     return Results.Json(result);
 });
 
-app.MapGet("/memory-limit", (HttpRequest httpRequest) =>
-{
-    _ = GC.AllocateArray<string>(256 * 1024 * 1024);
-
-    var memoryInfo = GC.GetGCMemoryInfo();
-    return Results.Json(new { totalAvailableMemoryBytes = memoryInfo.TotalAvailableMemoryBytes });
-});
-
 app.Run();

--- a/samples/MinimalApi/Program.cs
+++ b/samples/MinimalApi/Program.cs
@@ -80,4 +80,12 @@ app.MapPost("/hash", async (HttpRequest httpRequest) =>
     return Results.Json(result);
 });
 
+app.MapGet("/memory-limit", (HttpRequest httpRequest) =>
+{
+    _ = GC.AllocateArray<string>(256 * 1024 * 1024);
+
+    var memoryInfo = GC.GetGCMemoryInfo();
+    return Results.Json(new { totalAvailableMemoryBytes = memoryInfo.TotalAvailableMemoryBytes });
+});
+
 app.Run();

--- a/src/AwsLambdaTestServer/LambdaTestServer.cs
+++ b/src/AwsLambdaTestServer/LambdaTestServer.cs
@@ -313,7 +313,7 @@ public class LambdaTestServer : IDisposable
         // See https://github.com/aws/aws-lambda-dotnet/pull/1595
         if (Options.DisableMemoryLimitCheck)
         {
-            Environment.SetEnvironmentVariable("AWS_LAMBDA_DOTNET_DISABLE_MEMORY_LIMIT_CHECK", Options.DisableMemoryLimitCheck.ToString());
+            Environment.SetEnvironmentVariable("AWS_LAMBDA_DOTNET_DISABLE_MEMORY_LIMIT_CHECK", bool.TrueString);
         }
 #endif
     }

--- a/src/AwsLambdaTestServer/LambdaTestServer.cs
+++ b/src/AwsLambdaTestServer/LambdaTestServer.cs
@@ -313,7 +313,7 @@ public class LambdaTestServer : IDisposable
         // See https://github.com/aws/aws-lambda-dotnet/pull/1595
         if (Options.DisableMemoryLimitCheck)
         {
-            Environment.SetEnvironmentVariable("AWS_LAMBDA_FUNCTION_MEMORY_SIZE", Options.DisableMemoryLimitCheck.ToString());
+            Environment.SetEnvironmentVariable("AWS_LAMBDA_DOTNET_DISABLE_MEMORY_LIMIT_CHECK", Options.DisableMemoryLimitCheck.ToString());
         }
 #endif
     }

--- a/src/AwsLambdaTestServer/LambdaTestServer.cs
+++ b/src/AwsLambdaTestServer/LambdaTestServer.cs
@@ -79,6 +79,9 @@ public class LambdaTestServer : IDisposable
     /// </summary>
     public static void ClearLambdaEnvironmentVariables()
     {
+#if NET8_0_OR_GREATER
+        Environment.SetEnvironmentVariable("AWS_LAMBDA_DOTNET_DISABLE_MEMORY_LIMIT_CHECK", null);
+#endif
         Environment.SetEnvironmentVariable("AWS_LAMBDA_FUNCTION_MEMORY_SIZE", null);
         Environment.SetEnvironmentVariable("AWS_LAMBDA_FUNCTION_NAME", null);
         Environment.SetEnvironmentVariable("AWS_LAMBDA_FUNCTION_VERSION", null);
@@ -305,6 +308,14 @@ public class LambdaTestServer : IDisposable
         Environment.SetEnvironmentVariable("AWS_LAMBDA_LOG_STREAM_NAME", Options.LogStreamName);
         Environment.SetEnvironmentVariable("AWS_LAMBDA_RUNTIME_API", $"{baseAddress.Host}:{baseAddress.Port}");
         Environment.SetEnvironmentVariable("_HANDLER", Options.FunctionHandler);
+
+#if NET8_0_OR_GREATER
+        // See https://github.com/aws/aws-lambda-dotnet/pull/1595
+        if (Options.DisableMemoryLimitCheck)
+        {
+            Environment.SetEnvironmentVariable("AWS_LAMBDA_FUNCTION_MEMORY_SIZE", Options.DisableMemoryLimitCheck.ToString());
+        }
+#endif
     }
 
     private void ThrowIfDisposed()

--- a/src/AwsLambdaTestServer/LambdaTestServerOptions.cs
+++ b/src/AwsLambdaTestServer/LambdaTestServerOptions.cs
@@ -45,7 +45,7 @@ public sealed class LambdaTestServerOptions
     /// Gets or sets the amount of memory available to the function in megabytes during execution. The default value is 128.
     /// </summary>
     /// <remarks>
-    /// This limit is not enforced and is only used for reporting into the Lambda context.
+    /// This limit is not enforced and is only used for reporting into the Lambda context unless you are using .NET 8 and later.
     /// </remarks>
     public int FunctionMemorySize { get; set; }
 

--- a/src/AwsLambdaTestServer/LambdaTestServerOptions.cs
+++ b/src/AwsLambdaTestServer/LambdaTestServerOptions.cs
@@ -31,6 +31,13 @@ public sealed class LambdaTestServerOptions
     /// </summary>
     public Action<IServiceCollection>? Configure { get; set; }
 
+#if NET8_0_OR_GREATER
+    /// <summary>
+    /// Gets or sets a value indicating whether to disable the memory limit check for the Lambda function.
+    /// </summary>
+    public bool DisableMemoryLimitCheck { get; set; }
+#endif
+
     /// <summary>
     /// Gets or sets the ARN of the Lambda function being tested.
     /// </summary>
@@ -41,12 +48,21 @@ public sealed class LambdaTestServerOptions
     /// </summary>
     public string FunctionHandler { get; set; }
 
+#if NET8_0_OR_GREATER
+    /// <summary>
+    /// Gets or sets the amount of memory available to the function in megabytes during execution.
+    /// </summary>
+    /// <remarks>
+    /// To disable enforcement of this limit by the AWS Lambda runtime, set <see cref="DisableMemoryLimitCheck"/> to <see langword="true"/>.
+    /// </remarks>
+#else
     /// <summary>
     /// Gets or sets the amount of memory available to the function in megabytes during execution. The default value is 128.
     /// </summary>
     /// <remarks>
-    /// This limit is not enforced and is only used for reporting into the Lambda context unless you are using .NET 8 and later.
+    /// This limit is not enforced and is only used for reporting into the Lambda context.
     /// </remarks>
+#endif
     public int FunctionMemorySize { get; set; }
 
     /// <summary>

--- a/src/AwsLambdaTestServer/MartinCostello.Testing.AwsLambdaTestServer.csproj
+++ b/src/AwsLambdaTestServer/MartinCostello.Testing.AwsLambdaTestServer.csproj
@@ -9,7 +9,7 @@
     <PackageValidationBaselineVersion>0.7.0</PackageValidationBaselineVersion>
     <RootNamespace>MartinCostello.Testing.AwsLambdaTestServer</RootNamespace>
     <Summary>$(Description)</Summary>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <Title>AWS Lambda Test Server</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/AwsLambdaTestServer/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/AwsLambdaTestServer/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/AwsLambdaTestServer/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/AwsLambdaTestServer/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,3 @@
+#nullable enable
+MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServerOptions.DisableMemoryLimitCheck.get -> bool
+MartinCostello.Testing.AwsLambdaTestServer.LambdaTestServerOptions.DisableMemoryLimitCheck.set -> void

--- a/tests/AwsLambdaTestServer.Tests/AssemblyFixture.cs
+++ b/tests/AwsLambdaTestServer.Tests/AssemblyFixture.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Martin Costello, 2019. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using Xunit.Sdk;
+
+[assembly: TestFramework("MartinCostello.Testing.AwsLambdaTestServer.AssemblyFixture", "MartinCostello.Testing.AwsLambdaTestServer.Tests")]
+
+namespace MartinCostello.Testing.AwsLambdaTestServer;
+
+public sealed class AssemblyFixture : XunitTestFramework
+{
+    // Read the default memory limits before any of the tests execute any code that may change it.
+    // The cast to ulong is required for the setting to be respected by the runtime.
+    // See https://github.com/aws/aws-lambda-dotnet/pull/1595#issuecomment-1771747410.
+    private static readonly ulong DefaultMemory = (ulong)GC.GetGCMemoryInfo().TotalAvailableMemoryBytes;
+
+    public AssemblyFixture(IMessageSink messageSink)
+      : base(messageSink)
+    {
+        ResetMemoryLimits();
+    }
+
+    public static void ResetMemoryLimits()
+    {
+        Debug.Assert(DefaultMemory != 134217728, "The default value of TotalAvailableMemoryBytes should not be 128MB.");
+
+        // Undo any changes that Amazon.Lambda.RuntimeSupport makes internally
+        AppContext.SetData("GCHeapHardLimit", DefaultMemory);
+        GC.RefreshMemoryLimit();
+    }
+}

--- a/tests/AwsLambdaTestServer.Tests/AwsIntegrationTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/AwsIntegrationTests.cs
@@ -37,7 +37,7 @@ public static class AwsIntegrationTests
 
             if (!cancellationTokenSource.IsCancellationRequested)
             {
-                cancellationTokenSource.Cancel();
+                await cancellationTokenSource.CancelAsync();
             }
         });
 

--- a/tests/AwsLambdaTestServer.Tests/Examples.cs
+++ b/tests/AwsLambdaTestServer.Tests/Examples.cs
@@ -42,7 +42,7 @@ public static class Examples
 
             if (!cancellationTokenSource.IsCancellationRequested)
             {
-                cancellationTokenSource.Cancel();
+                await cancellationTokenSource.CancelAsync();
             }
         });
 

--- a/tests/AwsLambdaTestServer.Tests/HttpLambdaTestServerTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/HttpLambdaTestServerTests.cs
@@ -40,7 +40,7 @@ public class HttpLambdaTestServerTests : ITestOutputHelperAccessor
 
             if (!cts.IsCancellationRequested)
             {
-                cts.Cancel();
+                await cts.CancelAsync();
             }
         });
 
@@ -81,7 +81,7 @@ public class HttpLambdaTestServerTests : ITestOutputHelperAccessor
 
             if (!cts.IsCancellationRequested)
             {
-                cts.Cancel();
+                await cts.CancelAsync();
             }
         });
 
@@ -133,7 +133,7 @@ public class HttpLambdaTestServerTests : ITestOutputHelperAccessor
 
             if (!cts.IsCancellationRequested)
             {
-                cts.Cancel();
+                await cts.CancelAsync();
             }
         });
 

--- a/tests/AwsLambdaTestServer.Tests/HttpLambdaTestServerTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/HttpLambdaTestServerTests.cs
@@ -9,14 +9,9 @@ using Microsoft.Extensions.Logging;
 namespace MartinCostello.Testing.AwsLambdaTestServer;
 
 [Collection(nameof(LambdaTestServerCollection))]
-public class HttpLambdaTestServerTests : ITestOutputHelperAccessor
+public class HttpLambdaTestServerTests(ITestOutputHelper outputHelper) : ITestOutputHelperAccessor
 {
-    public HttpLambdaTestServerTests(ITestOutputHelper outputHelper)
-    {
-        OutputHelper = outputHelper;
-    }
-
-    public ITestOutputHelper? OutputHelper { get; set; }
+    public ITestOutputHelper? OutputHelper { get; set; } = outputHelper;
 
     [Fact]
     public async Task Function_Can_Process_Request()

--- a/tests/AwsLambdaTestServer.Tests/LambdaTestRequestTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/LambdaTestRequestTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Martin Costello, 2019. All rights reserved.
+﻿// Copyright (c) Martin Costello, 2019. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 namespace MartinCostello.Testing.AwsLambdaTestServer;
@@ -19,7 +19,7 @@ public static class LambdaTestRequestTests
     public static void Constructor_Sets_Properties()
     {
         // Arrange
-        byte[] content = new[] { (byte)1 };
+        byte[] content = [(byte)1];
 
         // Act
         var actual = new LambdaTestRequest(content);

--- a/tests/AwsLambdaTestServer.Tests/LambdaTestServerTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/LambdaTestServerTests.cs
@@ -12,7 +12,6 @@ using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
-using Skip = Xunit.Skip;
 
 namespace MartinCostello.Testing.AwsLambdaTestServer;
 
@@ -444,13 +443,11 @@ public class LambdaTestServerTests(ITestOutputHelper outputHelper) : ITestOutput
         remainingTime.Minutes.ShouldBe(options.FunctionTimeout.Minutes);
     }
 
-    [SkippableTheory]
+    [Theory]
     [InlineData(false)]
     [InlineData(true)]
     public async Task Can_Enforce_Memory_Limit(bool disableMemoryLimitCheck)
     {
-        Skip.If(OperatingSystem.IsMacOS(), "Changing the GC memory limits is not supported on macOS.");
-
         // Arrange
         LambdaTestServer.ClearLambdaEnvironmentVariables();
         AssemblyFixture.ResetMemoryLimits();

--- a/tests/AwsLambdaTestServer.Tests/LambdaTestServerTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/LambdaTestServerTests.cs
@@ -329,7 +329,7 @@ public class LambdaTestServerTests : ITestOutputHelperAccessor
 
             if (!cts.IsCancellationRequested)
             {
-                cts.Cancel();
+                await cts.CancelAsync();
             }
         });
 
@@ -458,7 +458,7 @@ public class LambdaTestServerTests : ITestOutputHelperAccessor
 
             if (!cancellationTokenSource.IsCancellationRequested)
             {
-                cancellationTokenSource.Cancel();
+                await cancellationTokenSource.CancelAsync();
             }
         });
     }

--- a/tests/AwsLambdaTestServer.Tests/LambdaTestServerTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/LambdaTestServerTests.cs
@@ -16,14 +16,9 @@ using NSubstitute;
 namespace MartinCostello.Testing.AwsLambdaTestServer;
 
 [Collection(nameof(LambdaTestServerCollection))]
-public class LambdaTestServerTests : ITestOutputHelperAccessor
+public class LambdaTestServerTests(ITestOutputHelper outputHelper) : ITestOutputHelperAccessor
 {
-    public LambdaTestServerTests(ITestOutputHelper outputHelper)
-    {
-        OutputHelper = outputHelper;
-    }
-
-    public ITestOutputHelper? OutputHelper { get; set; }
+    public ITestOutputHelper? OutputHelper { get; set; } = outputHelper;
 
     [Fact]
     public void Constructor_Validates_Parameters()
@@ -72,7 +67,7 @@ public class LambdaTestServerTests : ITestOutputHelperAccessor
     {
         // Arrange
         using var target = new LambdaTestServer();
-        var request = new LambdaTestRequest(Array.Empty<byte>());
+        var request = new LambdaTestRequest([]);
 
         // Act and Assert
         await Assert.ThrowsAsync<InvalidOperationException>(() => target.EnqueueAsync(request));
@@ -85,7 +80,7 @@ public class LambdaTestServerTests : ITestOutputHelperAccessor
         var target = new LambdaTestServer();
         target.Dispose();
 
-        var request = new LambdaTestRequest(Array.Empty<byte>());
+        var request = new LambdaTestRequest([]);
 
         // Act
         await Assert.ThrowsAsync<ObjectDisposedException>(() => target.EnqueueAsync(request));
@@ -96,7 +91,7 @@ public class LambdaTestServerTests : ITestOutputHelperAccessor
     {
         // Arrange
         using var target = new LambdaTestServer();
-        var request = new LambdaTestRequest(Array.Empty<byte>());
+        var request = new LambdaTestRequest([]);
 
         await target.StartAsync();
 
@@ -407,7 +402,7 @@ public class LambdaTestServerTests : ITestOutputHelperAccessor
 
         await server.StartAsync(cts.Token);
 
-        var request = new LambdaTestRequest(Array.Empty<byte>(), "my-request-id")
+        var request = new LambdaTestRequest([], "my-request-id")
         {
             ClientContext = @"{""client"":{""app_title"":""my-app""}}",
             CognitoIdentity = @"{""cognitoIdentityId"":""my-identity""}",

--- a/tests/AwsLambdaTestServer.Tests/LambdaTestServerTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/LambdaTestServerTests.cs
@@ -443,9 +443,11 @@ public class LambdaTestServerTests(ITestOutputHelper outputHelper) : ITestOutput
         remainingTime.Minutes.ShouldBe(options.FunctionTimeout.Minutes);
     }
 
-    [Fact]
+    [SkippableFact]
     public async Task Enforces_Memory_Limit()
     {
+        Skip.If(OperatingSystem.IsMacOS(), "Changing the GC memory limits is not supported on macOS.");
+
         // Arrange
         LambdaTestServer.ClearLambdaEnvironmentVariables();
 

--- a/tests/AwsLambdaTestServer.Tests/LambdaTestServerTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/LambdaTestServerTests.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
+using Skip = Xunit.Skip;
 
 namespace MartinCostello.Testing.AwsLambdaTestServer;
 

--- a/tests/AwsLambdaTestServer.Tests/LambdaTestServerTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/LambdaTestServerTests.cs
@@ -445,9 +445,10 @@ public class LambdaTestServerTests(ITestOutputHelper outputHelper) : ITestOutput
 
     [SkippableTheory]
     [InlineData(false)]
-    [InlineData(true, Skip = "Depends on aws/aws-lambda-dotnet#1595.")]
+    [InlineData(true)]
     public async Task Can_Enforce_Memory_Limit(bool disableMemoryLimitCheck)
     {
+        Skip.If(disableMemoryLimitCheck, "Depends on aws/aws-lambda-dotnet#1595.");
         Skip.If(OperatingSystem.IsMacOS(), "Changing the GC memory limits is not supported on macOS.");
 
         // Arrange

--- a/tests/AwsLambdaTestServer.Tests/LambdaTestServerTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/LambdaTestServerTests.cs
@@ -449,7 +449,6 @@ public class LambdaTestServerTests(ITestOutputHelper outputHelper) : ITestOutput
     [InlineData(true)]
     public async Task Can_Enforce_Memory_Limit(bool disableMemoryLimitCheck)
     {
-        Skip.If(disableMemoryLimitCheck, "Depends on aws/aws-lambda-dotnet#1595.");
         Skip.If(OperatingSystem.IsMacOS(), "Changing the GC memory limits is not supported on macOS.");
 
         // Arrange

--- a/tests/AwsLambdaTestServer.Tests/LambdaTestServerTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/LambdaTestServerTests.cs
@@ -443,11 +443,13 @@ public class LambdaTestServerTests(ITestOutputHelper outputHelper) : ITestOutput
         remainingTime.Minutes.ShouldBe(options.FunctionTimeout.Minutes);
     }
 
-    [Theory]
+    [SkippableTheory]
     [InlineData(false)]
     [InlineData(true)]
     public async Task Can_Enforce_Memory_Limit(bool disableMemoryLimitCheck)
     {
+        Xunit.Skip.If(OperatingSystem.IsMacOS(), "Changing the GC memory limits is not supported on macOS.");
+
         // Arrange
         LambdaTestServer.ClearLambdaEnvironmentVariables();
         AssemblyFixture.ResetMemoryLimits();

--- a/tests/AwsLambdaTestServer.Tests/MartinCostello.Testing.AwsLambdaTestServer.Tests.csproj
+++ b/tests/AwsLambdaTestServer.Tests/MartinCostello.Testing.AwsLambdaTestServer.Tests.csproj
@@ -6,7 +6,7 @@
     <NoWarn>$(NoWarn);CA1062;CA1707;CA1711;CA1861;CA2007;CA2234;SA1600</NoWarn>
     <RootNamespace>MartinCostello.Testing.AwsLambdaTestServer</RootNamespace>
     <Summary>$(Description)</Summary>
-    <TargetFrameworks>net7.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
@@ -30,7 +30,7 @@
   </ItemGroup>
   <PropertyGroup>
     <CollectCoverage>true</CollectCoverage>
-    <CoverletOutput>$([System.IO.Path]::Combine($(OutputPath), 'coverage', 'coverage'))</CoverletOutput>
+    <CoverletOutput>$([System.IO.Path]::Combine($(ArtifactsPath), 'coverage', 'coverage'))</CoverletOutput>
     <CoverletOutputFormat>cobertura,json</CoverletOutputFormat>
     <Exclude>[Amazon.Lambda*]*,[MathsFunctions*]*,[MinimalApi*]*,[xunit.*]*</Exclude>
     <Threshold>84</Threshold>

--- a/tests/AwsLambdaTestServer.Tests/MyHandler.cs
+++ b/tests/AwsLambdaTestServer.Tests/MyHandler.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Martin Costello, 2019. All rights reserved.
+﻿// Copyright (c) Martin Costello, 2019. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using Amazon.Lambda.Core;

--- a/tests/AwsLambdaTestServer.Tests/ParallelismTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/ParallelismTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Martin Costello, 2019. All rights reserved.
+﻿// Copyright (c) Martin Costello, 2019. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using System.Collections.Concurrent;
@@ -23,46 +23,33 @@ public static class ParallelismTests
         using var httpClient = server.CreateClient();
 
         // Enqueue the requests to process in the background
-        var completedAdding = EnqueueInParallel(messageCount, server);
+        var addTask = EnqueueInParallel(messageCount, server);
 
         // Start a task to consume the responses in the background
-        var completedProcessing = Assert(completedAdding, messageCount, cts);
+        var processTask = Assert(addTask, messageCount, cts);
 
         // Act - Start the function processing
         await ReverseFunction.RunAsync(httpClient, cts.Token);
 
         // Assert
-        int actual = await completedProcessing.Task;
+        int actual = await processTask.Task;
         actual.ShouldBe(expected);
     }
 
-    private static TaskCompletionSource<IReadOnlyCollection<LambdaTestContext>> EnqueueInParallel(
+    private static async Task<IReadOnlyCollection<LambdaTestContext>> EnqueueInParallel(
         int count,
         LambdaTestServer server)
     {
         var collection = new ConcurrentBag<LambdaTestContext>();
-        var completionSource = new TaskCompletionSource<IReadOnlyCollection<LambdaTestContext>>();
 
-        int queued = 0;
+        await Task.Yield();
+        await Parallel.ForAsync(0, count, async (i, _) => collection.Add(await server.EnqueueAsync(new[] { i })));
 
-        // Enqueue the specified number of items in parallel
-        Parallel.For(0, count, async (i) =>
-        {
-            var context = await server.EnqueueAsync(new[] { i });
-
-            collection.Add(context);
-
-            if (Interlocked.Increment(ref queued) == count)
-            {
-                completionSource.SetResult(collection);
-            }
-        });
-
-        return completionSource;
+        return collection;
     }
 
     private static TaskCompletionSource<int> Assert(
-        TaskCompletionSource<IReadOnlyCollection<LambdaTestContext>> completedAdding,
+        Task<IReadOnlyCollection<LambdaTestContext>> addTask,
         int messages,
         CancellationTokenSource cts)
     {
@@ -70,7 +57,7 @@ public static class ParallelismTests
 
         _ = Task.Run(async () =>
         {
-            var collection = await completedAdding.Task;
+            var collection = await addTask;
             collection.Count.ShouldBe(messages);
 
             int actual = 0;

--- a/tests/AwsLambdaTestServer.Tests/ParallelismTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/ParallelismTests.cs
@@ -87,7 +87,7 @@ public static class ParallelismTests
             }
 
             completionSource.SetResult(actual);
-            cts.Cancel();
+            await cts.CancelAsync();
         });
 
         return completionSource;

--- a/tests/AwsLambdaTestServer.Tests/ReverseFunctionTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/ReverseFunctionTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Martin Costello, 2019. All rights reserved.
+﻿// Copyright (c) Martin Costello, 2019. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using System.Text.Json;
@@ -17,7 +17,7 @@ public static class ReverseFunctionTests
 
         await server.StartAsync(cancellationTokenSource.Token);
 
-        int[] value = new[] { 1, 2, 3 };
+        int[] value = [1, 2, 3];
         byte[] json = JsonSerializer.SerializeToUtf8Bytes(value);
 
         LambdaTestContext context = await server.EnqueueAsync(json);
@@ -35,6 +35,6 @@ public static class ReverseFunctionTests
         var actual = JsonSerializer.Deserialize<int[]>(response.Content);
 
         Assert.NotNull(actual);
-        Assert.Equal(new[] { 3, 2, 1 }, actual);
+        Assert.Equal([3, 2, 1], actual);
     }
 }

--- a/tests/AwsLambdaTestServer.Tests/ReverseFunctionTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/ReverseFunctionTests.cs
@@ -35,6 +35,7 @@ public static class ReverseFunctionTests
         var actual = JsonSerializer.Deserialize<int[]>(response.Content);
 
         Assert.NotNull(actual);
-        Assert.Equal([3, 2, 1], actual);
+        int[] expected = [3, 2, 1];
+        Assert.Equal(expected, actual);
     }
 }

--- a/tests/AwsLambdaTestServer.Tests/ReverseFunctionWithCustomOptionsTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/ReverseFunctionWithCustomOptionsTests.cs
@@ -41,6 +41,7 @@ public static class ReverseFunctionWithCustomOptionsTests
         var actual = JsonSerializer.Deserialize<int[]>(response.Content);
 
         Assert.NotNull(actual);
-        Assert.Equal([3, 2, 1], actual);
+        int[] expected = [3, 2, 1];
+        Assert.Equal(expected, actual);
     }
 }

--- a/tests/AwsLambdaTestServer.Tests/ReverseFunctionWithCustomOptionsTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/ReverseFunctionWithCustomOptionsTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Martin Costello, 2019. All rights reserved.
+﻿// Copyright (c) Martin Costello, 2019. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using System.Text.Json;
@@ -24,7 +24,7 @@ public static class ReverseFunctionWithCustomOptionsTests
 
         await server.StartAsync(cancellationTokenSource.Token);
 
-        int[] value = new[] { 1, 2, 3 };
+        int[] value = [1, 2, 3];
         byte[] json = JsonSerializer.SerializeToUtf8Bytes(value);
 
         LambdaTestContext context = await server.EnqueueAsync(json);
@@ -41,6 +41,6 @@ public static class ReverseFunctionWithCustomOptionsTests
         var actual = JsonSerializer.Deserialize<int[]>(response.Content);
 
         Assert.NotNull(actual);
-        Assert.Equal(new[] { 3, 2, 1 }, actual);
+        Assert.Equal([3, 2, 1], actual);
     }
 }

--- a/tests/AwsLambdaTestServer.Tests/ReverseFunctionWithLoggingTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/ReverseFunctionWithLoggingTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Martin Costello, 2019. All rights reserved.
+﻿// Copyright (c) Martin Costello, 2019. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using System.Text.Json;
@@ -9,14 +9,9 @@ using Microsoft.Extensions.Logging;
 
 namespace MyFunctions;
 
-public class ReverseFunctionWithLoggingTests : ITestOutputHelperAccessor
+public class ReverseFunctionWithLoggingTests(ITestOutputHelper outputHelper) : ITestOutputHelperAccessor
 {
-    public ReverseFunctionWithLoggingTests(ITestOutputHelper outputHelper)
-    {
-        OutputHelper = outputHelper;
-    }
-
-    public ITestOutputHelper? OutputHelper { get; set; }
+    public ITestOutputHelper? OutputHelper { get; set; } = outputHelper;
 
     [RetryFact]
     public async Task Function_Reverses_Numbers_With_Logging()
@@ -30,7 +25,7 @@ public class ReverseFunctionWithLoggingTests : ITestOutputHelperAccessor
 
         await server.StartAsync(cancellationTokenSource.Token);
 
-        int[] value = new[] { 1, 2, 3 };
+        int[] value = [1, 2, 3];
         byte[] json = JsonSerializer.SerializeToUtf8Bytes(value);
 
         LambdaTestContext context = await server.EnqueueAsync(json);
@@ -48,6 +43,6 @@ public class ReverseFunctionWithLoggingTests : ITestOutputHelperAccessor
         var actual = JsonSerializer.Deserialize<int[]>(response.Content);
 
         Assert.NotNull(actual);
-        Assert.Equal(new[] { 3, 2, 1 }, actual);
+        Assert.Equal([3, 2, 1], actual);
     }
 }

--- a/tests/AwsLambdaTestServer.Tests/ReverseFunctionWithLoggingTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/ReverseFunctionWithLoggingTests.cs
@@ -43,6 +43,7 @@ public class ReverseFunctionWithLoggingTests(ITestOutputHelper outputHelper) : I
         var actual = JsonSerializer.Deserialize<int[]>(response.Content);
 
         Assert.NotNull(actual);
-        Assert.Equal([3, 2, 1], actual);
+        int[] expected = [3, 2, 1];
+        Assert.Equal(expected, actual);
     }
 }

--- a/tests/AwsLambdaTestServer.Tests/ReverseFunctionWithMobileSdkTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/ReverseFunctionWithMobileSdkTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Martin Costello, 2019. All rights reserved.
+﻿// Copyright (c) Martin Costello, 2019. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using System.Text.Json;
@@ -17,7 +17,7 @@ public static class ReverseFunctionWithMobileSdkTests
 
         await server.StartAsync(cancellationTokenSource.Token);
 
-        int[] value = new[] { 1, 2, 3 };
+        int[] value = [1, 2, 3];
         byte[] content = JsonSerializer.SerializeToUtf8Bytes(value);
 
         var request = new LambdaTestRequest(content)
@@ -41,6 +41,6 @@ public static class ReverseFunctionWithMobileSdkTests
         var actual = JsonSerializer.Deserialize<int[]>(response.Content);
 
         Assert.NotNull(actual);
-        Assert.Equal(new[] { 3, 2, 1 }, actual);
+        Assert.Equal([3, 2, 1], actual);
     }
 }

--- a/tests/AwsLambdaTestServer.Tests/ReverseFunctionWithMobileSdkTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/ReverseFunctionWithMobileSdkTests.cs
@@ -41,6 +41,7 @@ public static class ReverseFunctionWithMobileSdkTests
         var actual = JsonSerializer.Deserialize<int[]>(response.Content);
 
         Assert.NotNull(actual);
-        Assert.Equal([3, 2, 1], actual);
+        int[] expected = [3, 2, 1];
+        Assert.Equal(expected, actual);
     }
 }


### PR DESCRIPTION
- Update to .NET 8 and add `net8.0` target framework support.
- Add new `LambdaTestServerOptions.DisableMemoryLimitCheck` option for `net8.0`.
- Fix new code analysis warnings.
- Use `UseArtifactsOutput=true` instead of explicitly setting the output path, as well as dropping explicit use of `--configuration` now that the default is `Release`.
- Remove Microsoft.SourceLink.GitHub as it is now included in the .NET SDK.
