### PR TITLE
Increase test timeout

### DIFF
--- a/samples/MathsFunctions.Tests/MathsFunctionTests.cs
+++ b/samples/MathsFunctions.Tests/MathsFunctionTests.cs
@@ -19,7 +19,7 @@ public static class MathsFunctionTests
     {
         // Arrange
         using var server = new LambdaTestServer();
-        using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+        using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(2));
 
         await server.StartAsync(cancellationTokenSource.Token);
 

--- a/tests/AwsLambdaTestServer.Tests/ReverseFunctionTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/ReverseFunctionTests.cs
@@ -13,7 +13,7 @@ public static class ReverseFunctionTests
     {
         // Arrange
         using var server = new LambdaTestServer();
-        using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+        using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(2));
 
         await server.StartAsync(cancellationTokenSource.Token);
 

--- a/tests/AwsLambdaTestServer.Tests/ReverseFunctionWithCustomOptionsTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/ReverseFunctionWithCustomOptionsTests.cs
@@ -20,7 +20,7 @@ public static class ReverseFunctionWithCustomOptionsTests
         };
 
         using var server = new LambdaTestServer(options);
-        using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+        using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(2));
 
         await server.StartAsync(cancellationTokenSource.Token);
 


### PR DESCRIPTION
Increase timeout to 2 seconds to try and reduce flaky test runs in GitHub Actions.
