### PR TITLE
Use SHA-256 for checksums

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,6 +11,7 @@
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)AwsLambdaTestServer.snk</AssemblyOriginatorKeyFile>
     <Authors>martin_costello</Authors>
+    <ChecksumAlgorithm>SHA256</ChecksumAlgorithm>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)AwsLambdaTestServer.ruleset</CodeAnalysisRuleSet>
     <Company>https://github.com/martincostello/lambda-test-server</Company>
     <ContinuousIntegrationBuild Condition=" '$(CI)' != '' ">true</ContinuousIntegrationBuild>


### PR DESCRIPTION
Fix `BA2004` warning from Binskim.
