### PR TITLE
Pin .NET SDK version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,9 @@ jobs:
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
 
+    outputs:
+      dotnet-sdk-version: ${{ steps.setup-dotnet.outputs.dotnet-version }}
+
     permissions:
       id-token: write
 
@@ -53,6 +56,7 @@ jobs:
 
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@3447fd6a9f9e57506b15f895c5b76d3b197dc7c2 # v3.2.0
+      id: setup-dotnet
 
     - name: Setup NuGet cache
       uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
@@ -106,6 +110,8 @@ jobs:
 
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@3447fd6a9f9e57506b15f895c5b76d3b197dc7c2 # v3.2.0
+      with:
+        dotnet-version: ${{ needs.build.outputs.dotnet-sdk-version }}
 
     - name: Validate NuGet packages
       shell: pwsh
@@ -124,7 +130,7 @@ jobs:
         }
 
   publish-feedz-io:
-    needs: validate-packages
+    needs: [ build, validate-packages ]
     runs-on: ubuntu-latest
     if: |
       github.event.repository.fork == false &&
@@ -143,6 +149,8 @@ jobs:
 
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@3447fd6a9f9e57506b15f895c5b76d3b197dc7c2 # v3.2.0
+      with:
+        dotnet-version: ${{ needs.build.outputs.dotnet-sdk-version }}
 
     - name: Push NuGet packages to feedz.io
       shell: bash
@@ -152,7 +160,7 @@ jobs:
       run: dotnet nuget push "*.nupkg" --api-key "${API_KEY}" --skip-duplicate --source "${SOURCE}"
 
   publish-nuget:
-    needs: validate-packages
+    needs: [ build, validate-packages ]
     runs-on: ubuntu-latest
     if: |
       github.event.repository.fork == false &&
@@ -171,6 +179,8 @@ jobs:
 
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@3447fd6a9f9e57506b15f895c5b76d3b197dc7c2 # v3.2.0
+      with:
+        dotnet-version: ${{ needs.build.outputs.dotnet-sdk-version }}
 
     - name: Push NuGet packages to NuGet.org
       shell: bash


### PR DESCRIPTION
Use the same .NET SDK version to publish NuGet packages as to build them where there is no global.json to specify it.
