### PR TITLE
Use VersionOverride property

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,6 +7,7 @@
     <PackageVersion Include="coverlet.msbuild" Version="6.0.0" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.3.3" />
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageVersion Include="NSubstitute" Version="5.1.0" />
@@ -17,14 +18,6 @@
     <PackageVersion Include="xRetry" Version="1.9.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.4" />
     <PackageVersion Include="Xunit.SkippableFact" Version="1.4.13" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(IsPackable)' == 'true' ">
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="6.0.0" Condition=" '$(TargetFramework)' == 'net6.0' " />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="7.0.0" Condition=" '$(TargetFramework)' == 'net7.0' " />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.0" Condition=" '$(TargetFramework)' == 'net8.0' " />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(IsPackable)' != 'true' ">
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.0" Condition=" '$(TargetFramework)' == 'net8.0' " />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="All" />

--- a/src/AwsLambdaTestServer/MartinCostello.Testing.AwsLambdaTestServer.csproj
+++ b/src/AwsLambdaTestServer/MartinCostello.Testing.AwsLambdaTestServer.csproj
@@ -22,6 +22,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.TestHost" />
+    <PackageReference Update="Microsoft.AspNetCore.TestHost" VersionOverride="6.0.0" Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))" />
+    <PackageReference Update="Microsoft.AspNetCore.TestHost" VersionOverride="7.0.0" Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))" />
+    <PackageReference Update="Microsoft.AspNetCore.TestHost" VersionOverride="8.0.0" Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))" />
   </ItemGroup>
   <ItemGroup>
     <AdditionalFiles Include="PublicAPI\PublicAPI.Shipped.txt" />


### PR DESCRIPTION
Use the `VersionOverride` property to pin the version for the library instead of conditions in `Directory.Packages.props`.
