### PR TITLE
Ignore TestHost updates for 6.x and 7.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,5 @@ updates:
   ignore:
     - dependency-name: "AWSSDK.SQS"
       update-types: ["version-update:semver-patch"]
+    - dependency-name: "Microsoft.AspNetCore.TestHost"
+      versions: ["6.*", "7.*"]


### PR DESCRIPTION
See if that stops NuGet updates for the "pinned" versions.
