### PR TITLE
Solution improvements

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -25,6 +25,17 @@ charset = utf-8-bom
 # .NET Coding Conventions     #
 ###############################
 [*.{cs,vb}]
+
+# Enable style analyzers
+dotnet_analyzer_diagnostic.category-Style.severity = warning
+
+dotnet_diagnostic.IDE0005.severity = silent
+dotnet_diagnostic.IDE0045.severity = silent
+dotnet_diagnostic.IDE0046.severity = silent
+dotnet_diagnostic.IDE0058.severity = silent
+dotnet_diagnostic.IDE0072.severity = silent
+dotnet_diagnostic.IDE0079.severity = silent
+
 # Organize usings
 dotnet_sort_system_directives_first = true
 
@@ -87,6 +98,7 @@ csharp_style_expression_bodied_operators = false:none
 csharp_style_expression_bodied_properties = true:none
 csharp_style_expression_bodied_indexers = true:none
 csharp_style_expression_bodied_accessors = true:none
+csharp_style_expression_bodied_local_functions = when_on_single_line
 
 # Pattern matching preferences
 csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion

--- a/AwsLambdaTestServer.sln
+++ b/AwsLambdaTestServer.sln
@@ -65,8 +65,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 		.github\workflows\build.yml = .github\workflows\build.yml
 		.github\workflows\codeql-analysis.yml = .github\workflows\codeql-analysis.yml
 		.github\workflows\dependency-review.yml = .github\workflows\dependency-review.yml
+		.github\workflows\lint.yml = .github\workflows\lint.yml
 		.github\workflows\ossf-scorecard.yml = .github\workflows\ossf-scorecard.yml
-		.github\workflows\update-dotnet-sdk.yml = .github\workflows\update-dotnet-sdk.yml
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MinimalApi", "samples\MinimalApi\MinimalApi.csproj", "{D27E75B3-DAFF-485C-8D91-8ACF1190822A}"

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
   </ItemGroup>
   <PropertyGroup>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
+    <AnalysisMode>All</AnalysisMode>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)AwsLambdaTestServer.snk</AssemblyOriginatorKeyFile>
     <Authors>martin_costello</Authors>
     <ChecksumAlgorithm>SHA256</ChecksumAlgorithm>
@@ -19,6 +19,7 @@
     <Deterministic>true</Deterministic>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <GenerateGitMetadata Condition=" '$(CI)' != '' and '$(GenerateGitMetadata)' == '' ">true</GenerateGitMetadata>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -26,7 +27,6 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <NeutralLanguage>en-US</NeutralLanguage>
     <NoWarn>$(NoWarn);CA1848</NoWarn>
-    <NoWarn Condition=" '$(GenerateDocumentationFile)' != 'true' ">$(NoWarn);SA0001</NoWarn>
     <Nullable>enable</Nullable>
     <PackageIcon></PackageIcon>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
@@ -50,6 +50,10 @@
     <VersionPrefix Condition=" $(GITHUB_REF.StartsWith(`refs/tags/v`)) ">$(GITHUB_REF.Replace('refs/tags/v', ''))</VersionPrefix>
     <VersionSuffix Condition=" $(GITHUB_REF.StartsWith(`refs/tags/v`)) "></VersionSuffix>
     <FileVersion Condition=" '$(GITHUB_RUN_NUMBER)' != '' ">$(VersionPrefix).$(GITHUB_RUN_NUMBER)</FileVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(EnableReferenceTrimmer)' != 'false' and '$(GenerateDocumentationFile)' != 'true' ">
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);419;1570;1573;1574;1584;1591;SA0001;SA1602</NoWarn>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageIcon)' != '' ">
     <None Include="$(MSBuildThisFileDirectory)$(PackageIcon)" Pack="True" PackagePath="" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,5 +1,10 @@
 <Project>
   <ItemGroup>
+    <GlobalPackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" PrivateAssets="All" />
+    <GlobalPackageReference Include="ReferenceTrimmer" Version="3.3.3" PrivateAssets="All" />
+    <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="All" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageVersion Include="Amazon.Lambda.AspNetCoreServer.Hosting" Version="1.7.0" />
     <PackageVersion Include="Amazon.Lambda.RuntimeSupport" Version="1.10.0" />
     <PackageVersion Include="Amazon.Lambda.Serialization.Json" Version="2.2.0" />
@@ -8,24 +13,13 @@
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.3.3" />
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.2" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageVersion Include="NSubstitute" Version="5.1.0" />
     <PackageVersion Include="ReportGenerator" Version="5.2.4" />
     <PackageVersion Include="Shouldly" Version="4.2.1" />
-    <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
     <PackageVersion Include="xunit" Version="2.7.0" />
     <PackageVersion Include="xRetry" Version="1.9.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.7" />
     <PackageVersion Include="Xunit.SkippableFact" Version="1.4.13" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="All" />
-    <PackageReference Include="StyleCop.Analyzers" PrivateAssets="All" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(IsTestProject)' == 'true' ">
-    <PackageReference Include="coverlet.msbuild" PrivateAssets="All" />
-    <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
-    <PackageReference Include="ReportGenerator" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,4 +22,9 @@
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.7" />
     <PackageVersion Include="Xunit.SkippableFact" Version="1.4.13" />
   </ItemGroup>
+  <ItemGroup Condition=" '$(IsTestProject)' == 'true' ">
+    <PackageReference Include="coverlet.msbuild" PrivateAssets="All" />
+    <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" NoWarn="RT0003" />
+    <PackageReference Include="ReportGenerator" PrivateAssets="All" />
+  </ItemGroup>
 </Project>

--- a/samples/MinimalApi/Program.cs
+++ b/samples/MinimalApi/Program.cs
@@ -24,7 +24,7 @@ app.MapPost("/hash", async (HttpRequest httpRequest) =>
             statusCode: StatusCodes.Status400BadRequest);
     }
 
-    if (string.IsNullOrWhiteSpace((string)request.Format))
+    if (string.IsNullOrWhiteSpace(request.Format))
     {
         return Results.Problem(
             "No hash output format specified.",

--- a/src/AwsLambdaTestServer/LambdaTestRequest.cs
+++ b/src/AwsLambdaTestServer/LambdaTestRequest.cs
@@ -3,6 +3,8 @@
 
 namespace MartinCostello.Testing.AwsLambdaTestServer;
 
+#pragma warning disable CA1819
+
 /// <summary>
 /// A class representing a test request to an AWS Lambda function.
 /// </summary>
@@ -31,9 +33,7 @@ public class LambdaTestRequest
     /// <summary>
     /// Gets the raw byte content of the request to the function.
     /// </summary>
-#pragma warning disable CA1819
     public byte[] Content { get; }
-#pragma warning restore CA1819
 
     /// <summary>
     /// Gets or sets an optional string containing the serialized JSON

--- a/src/AwsLambdaTestServer/LambdaTestResponse.cs
+++ b/src/AwsLambdaTestServer/LambdaTestResponse.cs
@@ -1,7 +1,9 @@
-// Copyright (c) Martin Costello, 2019. All rights reserved.
+﻿// Copyright (c) Martin Costello, 2019. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 namespace MartinCostello.Testing.AwsLambdaTestServer;
+
+#pragma warning disable CA1819
 
 /// <summary>
 /// A class representing a test response from an AWS Lambda function. This class cannot be inherited.
@@ -24,9 +26,7 @@ public sealed class LambdaTestResponse
     /// <summary>
     /// Gets the raw byte content of the response from the function.
     /// </summary>
-#pragma warning disable CA1819
     public byte[] Content { get; }
-#pragma warning restore CA1819
 
     /// <summary>
     /// Gets the approximate duration of the Lambda function invocation.

--- a/src/AwsLambdaTestServer/LambdaTestServerOptions.cs
+++ b/src/AwsLambdaTestServer/LambdaTestServerOptions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Martin Costello, 2019. All rights reserved.
+﻿// Copyright (c) Martin Costello, 2019. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using Microsoft.Extensions.DependencyInjection;
@@ -55,6 +55,7 @@ public sealed class LambdaTestServerOptions
     /// <remarks>
     /// To disable enforcement of this limit by the AWS Lambda runtime, set <see cref="DisableMemoryLimitCheck"/> to <see langword="true"/>.
     /// </remarks>
+    public int FunctionMemorySize { get; set; }
 #else
     /// <summary>
     /// Gets or sets the amount of memory available to the function in megabytes during execution. The default value is 128.
@@ -62,8 +63,8 @@ public sealed class LambdaTestServerOptions
     /// <remarks>
     /// This limit is not enforced and is only used for reporting into the Lambda context.
     /// </remarks>
-#endif
     public int FunctionMemorySize { get; set; }
+#endif
 
     /// <summary>
     /// Gets or sets the name of the Lambda function being tested.

--- a/src/AwsLambdaTestServer/RuntimeHandler.cs
+++ b/src/AwsLambdaTestServer/RuntimeHandler.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Martin Costello, 2019. All rights reserved.
+﻿// Copyright (c) Martin Costello, 2019. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using System.Collections.Concurrent;
@@ -137,7 +137,7 @@ internal sealed class RuntimeHandler : IDisposable
             await _requests.Reader.WaitToReadAsync(cts.Token).ConfigureAwait(false);
             request = await _requests.Reader.ReadAsync().ConfigureAwait(false);
         }
-        catch (Exception ex) when (ex is OperationCanceledException || ex is ChannelClosedException)
+        catch (Exception ex) when (ex is OperationCanceledException or ChannelClosedException)
         {
             Logger?.LogInformation(
                 ex,

--- a/tests/AwsLambdaTestServer.Tests/Examples.cs
+++ b/tests/AwsLambdaTestServer.Tests/Examples.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Martin Costello, 2019. All rights reserved.
+﻿// Copyright (c) Martin Costello, 2019. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using System.Text.Json;
@@ -26,7 +26,7 @@ public static class Examples
         // Create a test request for the Lambda function being tested
         var value = new MyRequest()
         {
-            Values = new[] { 1, 2, 3 }, // The function returns the sum of the specified numbers
+            Values = [1, 2, 3], // The function returns the sum of the specified numbers
         };
 
         string requestJson = JsonSerializer.Serialize(value);

--- a/tests/AwsLambdaTestServer.Tests/HttpLambdaTestServerTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/HttpLambdaTestServerTests.cs
@@ -8,6 +8,8 @@ using Microsoft.Extensions.Logging;
 
 namespace MartinCostello.Testing.AwsLambdaTestServer;
 
+#pragma warning disable JSON002
+
 [Collection(nameof(LambdaTestServerCollection))]
 public class HttpLambdaTestServerTests(ITestOutputHelper outputHelper) : ITestOutputHelperAccessor
 {
@@ -18,9 +20,7 @@ public class HttpLambdaTestServerTests(ITestOutputHelper outputHelper) : ITestOu
     {
         // Arrange
         void Configure(IServiceCollection services)
-        {
-            services.AddLogging((builder) => builder.AddXUnit(this));
-        }
+            => services.AddLogging((builder) => builder.AddXUnit(this));
 
         using var server = new HttpLambdaTestServer(Configure);
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
@@ -59,9 +59,7 @@ public class HttpLambdaTestServerTests(ITestOutputHelper outputHelper) : ITestOu
     {
         // Arrange
         void Configure(IServiceCollection services)
-        {
-            services.AddLogging((builder) => builder.AddXUnit(this));
-        }
+            => services.AddLogging((builder) => builder.AddXUnit(this));
 
         using var server = new LambdaTestServer(Configure);
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
@@ -98,9 +96,7 @@ public class HttpLambdaTestServerTests(ITestOutputHelper outputHelper) : ITestOu
     {
         // Arrange
         void Configure(IServiceCollection services)
-        {
-            services.AddLogging((builder) => builder.AddXUnit(this));
-        }
+            => services.AddLogging((builder) => builder.AddXUnit(this));
 
         using var server = new LambdaTestServer(Configure);
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));

--- a/tests/AwsLambdaTestServer.Tests/LambdaTestServerTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/LambdaTestServerTests.cs
@@ -15,6 +15,8 @@ using NSubstitute;
 
 namespace MartinCostello.Testing.AwsLambdaTestServer;
 
+#pragma warning disable JSON002
+
 [Collection(nameof(LambdaTestServerCollection))]
 public class LambdaTestServerTests(ITestOutputHelper outputHelper) : ITestOutputHelperAccessor
 {
@@ -166,12 +168,7 @@ public class LambdaTestServerTests(ITestOutputHelper outputHelper) : ITestOutput
     public async Task Function_Can_Process_Request()
     {
         // Arrange
-        void Configure(IServiceCollection services)
-        {
-            services.AddLogging((builder) => builder.AddXUnit(this));
-        }
-
-        using var server = new LambdaTestServer(Configure);
+        using var server = new LambdaTestServer(ConfigureLogging);
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
 
         await server.StartAsync(cts.Token);
@@ -199,12 +196,7 @@ public class LambdaTestServerTests(ITestOutputHelper outputHelper) : ITestOutput
     public async Task Function_Can_Process_Request_With_Mobile_Sdk_Headers()
     {
         // Arrange
-        void Configure(IServiceCollection services)
-        {
-            services.AddLogging((builder) => builder.AddXUnit(this));
-        }
-
-        using var server = new LambdaTestServer(Configure);
+        using var server = new LambdaTestServer(ConfigureLogging);
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
 
         await server.StartAsync(cts.Token);
@@ -237,12 +229,7 @@ public class LambdaTestServerTests(ITestOutputHelper outputHelper) : ITestOutput
     public async Task Function_Can_Handle_Failed_Request()
     {
         // Arrange
-        void Configure(IServiceCollection services)
-        {
-            services.AddLogging((builder) => builder.AddXUnit(this));
-        }
-
-        using var server = new LambdaTestServer(Configure);
+        using var server = new LambdaTestServer(ConfigureLogging);
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
 
         await server.StartAsync(cts.Token);
@@ -268,12 +255,7 @@ public class LambdaTestServerTests(ITestOutputHelper outputHelper) : ITestOutput
     public async Task Function_Can_Handle_Failed_Initialization()
     {
         // Arrange
-        void Configure(IServiceCollection services)
-        {
-            services.AddLogging((builder) => builder.AddXUnit(this));
-        }
-
-        using var server = new LambdaTestServer(Configure);
+        using var server = new LambdaTestServer(ConfigureLogging);
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
 
         await server.StartAsync(cts.Token);
@@ -293,12 +275,7 @@ public class LambdaTestServerTests(ITestOutputHelper outputHelper) : ITestOutput
     public async Task Function_Can_Process_Multiple_Requests()
     {
         // Arrange
-        void Configure(IServiceCollection services)
-        {
-            services.AddLogging((builder) => builder.AddXUnit(this));
-        }
-
-        using var server = new LambdaTestServer(Configure);
+        using var server = new LambdaTestServer(ConfigureLogging);
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
 
         await server.StartAsync(cts.Token);
@@ -351,12 +328,7 @@ public class LambdaTestServerTests(ITestOutputHelper outputHelper) : ITestOutput
     public async Task Function_Returns_If_No_Requests_Within_Timeout()
     {
         // Arrange
-        void Configure(IServiceCollection services)
-        {
-            services.AddLogging((builder) => builder.AddXUnit(this));
-        }
-
-        using var server = new LambdaTestServer(Configure);
+        using var server = new LambdaTestServer(ConfigureLogging);
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
 
         await server.StartAsync(cts.Token);
@@ -514,6 +486,9 @@ public class LambdaTestServerTests(ITestOutputHelper outputHelper) : ITestOutput
         });
     }
 
+    private void ConfigureLogging(IServiceCollection services)
+        => services.AddLogging((builder) => builder.AddXUnit(this));
+
     private static class CustomFunction
     {
         internal static async Task RunAsync(HttpClient httpClient, CancellationToken cancellationToken)
@@ -614,7 +589,7 @@ public class LambdaTestServerTests(ITestOutputHelper outputHelper) : ITestOutput
         {
             var serverAddresses = Substitute.For<IServerAddressesFeature>();
 
-            serverAddresses.Addresses.Returns(Array.Empty<string>());
+            serverAddresses.Addresses.Returns([]);
 
             var server = Substitute.For<IServer>();
 

--- a/tests/AwsLambdaTestServer.Tests/MartinCostello.Testing.AwsLambdaTestServer.Tests.csproj
+++ b/tests/AwsLambdaTestServer.Tests/MartinCostello.Testing.AwsLambdaTestServer.Tests.csproj
@@ -15,13 +15,10 @@
     <PackageReference Include="Amazon.Lambda.RuntimeSupport" />
     <PackageReference Include="Amazon.Lambda.Serialization.Json" />
     <PackageReference Include="AWSSDK.SQS" />
-    <PackageReference Include="coverlet.msbuild" />
-    <PackageReference Include="GitHubActionsTestLogger" NoWarn="RT0003" />
     <PackageReference Include="MartinCostello.Logging.XUnit" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NSubstitute" />
-    <PackageReference Include="ReportGenerator" />
     <PackageReference Include="Shouldly" />
     <PackageReference Include="xRetry" />
     <PackageReference Include="xunit" />

--- a/tests/AwsLambdaTestServer.Tests/MartinCostello.Testing.AwsLambdaTestServer.Tests.csproj
+++ b/tests/AwsLambdaTestServer.Tests/MartinCostello.Testing.AwsLambdaTestServer.Tests.csproj
@@ -6,7 +6,7 @@
     <NoWarn>$(NoWarn);CA1062;CA1707;CA1711;CA1861;CA2007;CA2234;SA1600</NoWarn>
     <RootNamespace>MartinCostello.Testing.AwsLambdaTestServer</RootNamespace>
     <Summary>$(Description)</Summary>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
@@ -15,10 +15,13 @@
     <PackageReference Include="Amazon.Lambda.RuntimeSupport" />
     <PackageReference Include="Amazon.Lambda.Serialization.Json" />
     <PackageReference Include="AWSSDK.SQS" />
+    <PackageReference Include="coverlet.msbuild" />
+    <PackageReference Include="GitHubActionsTestLogger" NoWarn="RT0003" />
     <PackageReference Include="MartinCostello.Logging.XUnit" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NSubstitute" />
+    <PackageReference Include="ReportGenerator" />
     <PackageReference Include="Shouldly" />
     <PackageReference Include="xRetry" />
     <PackageReference Include="xunit" />


### PR DESCRIPTION
- Enable (almost) all built-in style analyzers.
- Fix new style warnings.
- Use global package references.
- Add reference trimmer analyzer.
