### PR TITLE
Fix style warnings

### DIFF
--- a/samples/MinimalApi.Tests/ApiTests.cs
+++ b/samples/MinimalApi.Tests/ApiTests.cs
@@ -65,7 +65,7 @@ public sealed class ApiTests : IAsyncLifetime, IDisposable
             {
                 try
                 {
-                    typeof(HashRequest).Assembly.EntryPoint!.Invoke(null, new[] { Array.Empty<string>() });
+                    typeof(HashRequest).Assembly.EntryPoint!.Invoke(null, []);
                 }
                 catch (Exception ex) when (LambdaServerWasShutDown(ex))
                 {

--- a/samples/MinimalApi.Tests/ApiTests.cs
+++ b/samples/MinimalApi.Tests/ApiTests.cs
@@ -65,7 +65,7 @@ public sealed class ApiTests : IAsyncLifetime, IDisposable
             {
                 try
                 {
-                    typeof(HashRequest).Assembly.EntryPoint!.Invoke(null, []);
+                    typeof(HashRequest).Assembly.EntryPoint!.Invoke(null, [Array.Empty<string>()]);
                 }
                 catch (Exception ex) when (LambdaServerWasShutDown(ex))
                 {

--- a/tests/AwsLambdaTestServer.Tests/LambdaTestRequestTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/LambdaTestRequestTests.cs
@@ -19,7 +19,7 @@ public static class LambdaTestRequestTests
     public static void Constructor_Sets_Properties()
     {
         // Arrange
-        byte[] content = [(byte)1];
+        byte[] content = [1];
 
         // Act
         var actual = new LambdaTestRequest(content);

--- a/tests/AwsLambdaTestServer.Tests/LambdaTestServerExtensionsTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/LambdaTestServerExtensionsTests.cs
@@ -14,10 +14,12 @@ public static class LambdaTestServerExtensionsTests
         byte[] content = null!;
         string value = null!;
 
+        byte[] emptyBytes = [];
+
         // Act
         await Assert.ThrowsAsync<ArgumentNullException>("content", () => server.EnqueueAsync(content));
         await Assert.ThrowsAsync<ArgumentNullException>("value", () => server.EnqueueAsync(value));
-        await Assert.ThrowsAsync<ArgumentNullException>("server", () => nullServer.EnqueueAsync([]));
+        await Assert.ThrowsAsync<ArgumentNullException>("server", () => nullServer.EnqueueAsync(emptyBytes));
         await Assert.ThrowsAsync<ArgumentNullException>("server", () => nullServer.EnqueueAsync(string.Empty));
     }
 }

--- a/tests/AwsLambdaTestServer.Tests/LambdaTestServerExtensionsTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/LambdaTestServerExtensionsTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Martin Costello, 2019. All rights reserved.
+﻿// Copyright (c) Martin Costello, 2019. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 namespace MartinCostello.Testing.AwsLambdaTestServer;
@@ -17,7 +17,7 @@ public static class LambdaTestServerExtensionsTests
         // Act
         await Assert.ThrowsAsync<ArgumentNullException>("content", () => server.EnqueueAsync(content));
         await Assert.ThrowsAsync<ArgumentNullException>("value", () => server.EnqueueAsync(value));
-        await Assert.ThrowsAsync<ArgumentNullException>("server", () => nullServer.EnqueueAsync(Array.Empty<byte>()));
+        await Assert.ThrowsAsync<ArgumentNullException>("server", () => nullServer.EnqueueAsync([]));
         await Assert.ThrowsAsync<ArgumentNullException>("server", () => nullServer.EnqueueAsync(string.Empty));
     }
 }


### PR DESCRIPTION
Fix new style warnings identified with .NET 9 in #588.
