### PR TITLE
Add tools manifest for dotnet-validate

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-validate": {
+      "version": "0.0.1-preview.304",
+      "commands": [
+        "dotnet-validate"
+      ]
+    }
+  }
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,13 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
 
+    - name: Setup .NET SDKs
+      uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
+      with:
+        dotnet-version: |
+          6.0.x
+          7.0.x
+
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
       id: setup-dotnet

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,7 @@ jobs:
 
     outputs:
       dotnet-sdk-version: ${{ steps.setup-dotnet.outputs.dotnet-version }}
+      dotnet-validate-version: ${{ steps.get-dotnet-validate-version.outputs.dotnet-validate-version }}
 
     permissions:
       id-token: write
@@ -99,6 +100,13 @@ jobs:
         path: ./artifacts/package/release
         if-no-files-found: error
 
+    - name: Get dotnet-validate version
+      id: get-dotnet-validate-version
+      shell: pwsh
+      run: |
+        $dotnetValidateVersion = (Get-Content "./.config/dotnet-tools.json" | Out-String | ConvertFrom-Json).tools.'dotnet-validate'.version
+        "dotnet-validate-version=${dotnetValidateVersion}" >> $env:GITHUB_OUTPUT
+
   validate-packages:
     needs: build
     runs-on: ubuntu-latest
@@ -116,8 +124,10 @@ jobs:
 
     - name: Validate NuGet packages
       shell: pwsh
+      env:
+        DOTNET_VALIDATE_VERSION: ${{ needs.build.outputs.dotnet-validate-version }}
       run: |
-        dotnet tool install --global dotnet-validate --version 0.0.1-preview.304
+        dotnet tool install --global dotnet-validate --version ${env:DOTNET_VALIDATE_VERSION}
         $packages = Get-ChildItem -Filter "*.nupkg" | ForEach-Object { $_.FullName }
         $invalidPackages = 0
         foreach ($package in $packages) {

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,13 +55,6 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
 
-    - name: Setup .NET SDKs
-      uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
-      with:
-        dotnet-version: |
-          6.0.x
-          7.0.x
-
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
       id: setup-dotnet


### PR DESCRIPTION
Add a .NET tools manifest for dotnet-validate so that dependabot can update it if there's ever a newer version released, and then reference that version in the build workflow.
