### PR TITLE
Attest artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,8 @@ jobs:
       dotnet-validate-version: ${{ steps.get-dotnet-validate-version.outputs.dotnet-validate-version }}
 
     permissions:
+      attestations: write
+      contents: read
       id-token: write
 
     strategy:
@@ -86,6 +88,17 @@ jobs:
         file: ./artifacts/coverage/coverage.net8.0.cobertura.xml
         flags: ${{ matrix.os_name }}
         token: ${{ secrets.CODECOV_TOKEN }}
+
+    - name: Attest artifacts
+      uses: actions/attest-build-provenance@951c0c5f8e375ad4efad33405ab77f7ded2358e4 # v1.1.1
+      if: |
+        runner.os == 'Windows' &&
+        github.event.repository.fork == false &&
+        (github.ref_name == github.event.repository.default_branch || startsWith(github.ref, 'refs/tags/v'))
+      with:
+        subject-path: |
+          ./artifacts/bin/MartinCostello.Testing.AwsLambdaTestServer/release*/*.dll
+          ./artifacts/package/release/*
 
     - name: Publish artifacts
       uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ packages
 TestResults
 UpgradeLog*.htm
 UpgradeLog*.XML
+*.binlog
 *.coverage
 *.DotSettings
 *.log


### PR DESCRIPTION
- Attest the binaries and packages from the build artifacts.
- Ignore any `binlog` files.
