### PR TITLE
Fix potential deadlock

### DIFF
--- a/tests/AwsLambdaTestServer.Tests/AwsIntegrationTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/AwsIntegrationTests.cs
@@ -19,9 +19,11 @@ public static class AwsIntegrationTests
         Xunit.Skip.If(GetAwsCredentials() is null, "No AWS credentials are configured.");
 
         using var server = new LambdaTestServer();
-        using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        using var cancellationTokenSource = new CancellationTokenSource();
 
         await server.StartAsync(cancellationTokenSource.Token);
+
+        cancellationTokenSource.CancelAfter(TimeSpan.FromSeconds(5));
 
         var request = new QueueExistsRequest()
         {

--- a/tests/AwsLambdaTestServer.Tests/Examples.cs
+++ b/tests/AwsLambdaTestServer.Tests/Examples.cs
@@ -18,10 +18,13 @@ public static class Examples
 
         // Create a cancellation token that stops the server listening for new requests.
         // Auto-cancel the server after 2 seconds in case something goes wrong and the request is not handled.
-        using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        using var cancellationTokenSource = new CancellationTokenSource();
 
         // Start the test server so it is ready to listen for requests from the Lambda runtime
         await server.StartAsync(cancellationTokenSource.Token);
+
+        // Now that the server has started, cancel it after 2 seconds if no requests are processed
+        cancellationTokenSource.CancelAfter(TimeSpan.FromSeconds(2));
 
         // Create a test request for the Lambda function being tested
         var value = new MyRequest()

--- a/tests/AwsLambdaTestServer.Tests/HttpLambdaTestServerTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/HttpLambdaTestServerTests.cs
@@ -23,9 +23,11 @@ public class HttpLambdaTestServerTests(ITestOutputHelper outputHelper) : ITestOu
             => services.AddLogging((builder) => builder.AddXUnit(this));
 
         using var server = new HttpLambdaTestServer(Configure);
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        using var cts = new CancellationTokenSource();
 
         await server.StartAsync(cts.Token);
+
+        cts.CancelAfter(TimeSpan.FromSeconds(2));
 
         var context = await server.EnqueueAsync(@"{""Values"": [ 1, 2, 3 ]}");
 
@@ -62,9 +64,11 @@ public class HttpLambdaTestServerTests(ITestOutputHelper outputHelper) : ITestOu
             => services.AddLogging((builder) => builder.AddXUnit(this));
 
         using var server = new LambdaTestServer(Configure);
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        using var cts = new CancellationTokenSource();
 
         await server.StartAsync(cts.Token);
+
+        cts.CancelAfter(TimeSpan.FromSeconds(2));
 
         var context = await server.EnqueueAsync(@"{""Values"": null}");
 
@@ -99,9 +103,11 @@ public class HttpLambdaTestServerTests(ITestOutputHelper outputHelper) : ITestOu
             => services.AddLogging((builder) => builder.AddXUnit(this));
 
         using var server = new LambdaTestServer(Configure);
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        using var cts = new CancellationTokenSource();
 
         await server.StartAsync(cts.Token);
+
+        cts.CancelAfter(TimeSpan.FromSeconds(2));
 
         var channels = new List<(int Expected, LambdaTestContext Context)>();
 


### PR DESCRIPTION
- Fix a potential deadlock where the server never stops by checking the result of `WaitToReadAsync()` and by passing the `CancellationToken` to `ReadAsync()`.
- Give the server as long as it needs to start in tests/examples, then cancel after started.
