### PR TITLE
Remove redundant condition

### DIFF
--- a/src/AwsLambdaTestServer/LambdaTestServer.cs
+++ b/src/AwsLambdaTestServer/LambdaTestServer.cs
@@ -333,9 +333,7 @@ public class LambdaTestServer : IDisposable
 #endif
     }
 
-#if NET5_0_OR_GREATER
     [System.Diagnostics.CodeAnalysis.MemberNotNull(nameof(_server))]
-#endif
     private void ThrowIfNotStarted()
     {
         if (_server is null)


### PR DESCRIPTION
The minimum target is now `net6.0` so the pre-processor condition is redundant.
