### PR TITLE
.NET 9 preparation

### DIFF
--- a/AwsLambdaTestServer.ruleset
+++ b/AwsLambdaTestServer.ruleset
@@ -3,6 +3,8 @@
   <IncludeAll Action="Warning" />
   <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
     <Rule Id="CA1303" Action="None" />
+    <Rule Id="CA1515" Action="None" />
+    <Rule Id="CA1848" Action="None" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
     <Rule Id="AD0001" Action="None" />

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,7 +26,6 @@
     <LangVersion>latest</LangVersion>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <NoWarn>$(NoWarn);CA1848</NoWarn>
     <Nullable>enable</Nullable>
     <PackageIcon></PackageIcon>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>

--- a/samples/MathsFunctions.Tests/MathsFunctions.Tests.csproj
+++ b/samples/MathsFunctions.Tests/MathsFunctions.Tests.csproj
@@ -10,7 +10,6 @@
     <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Shouldly" />
     <PackageReference Include="xRetry" />

--- a/src/AwsLambdaTestServer/MartinCostello.Testing.AwsLambdaTestServer.csproj
+++ b/src/AwsLambdaTestServer/MartinCostello.Testing.AwsLambdaTestServer.csproj
@@ -29,6 +29,8 @@
   <ItemGroup>
     <AdditionalFiles Include="PublicAPI\PublicAPI.Shipped.txt" />
     <AdditionalFiles Include="PublicAPI\PublicAPI.Unshipped.txt" />
+  </ItemGroup>
+  <ItemGroup Condition="Exists('PublicAPI\$(TargetFramework)')">
     <AdditionalFiles Include="PublicAPI\$(TargetFramework)\PublicAPI.Shipped.txt" />
     <AdditionalFiles Include="PublicAPI\$(TargetFramework)\PublicAPI.Unshipped.txt" />
   </ItemGroup>

--- a/tests/AwsLambdaTestServer.Tests/MartinCostello.Testing.AwsLambdaTestServer.Tests.csproj
+++ b/tests/AwsLambdaTestServer.Tests/MartinCostello.Testing.AwsLambdaTestServer.Tests.csproj
@@ -16,7 +16,6 @@
     <PackageReference Include="Amazon.Lambda.Serialization.Json" />
     <PackageReference Include="AWSSDK.SQS" />
     <PackageReference Include="MartinCostello.Logging.XUnit" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="Shouldly" />

--- a/tests/AwsLambdaTestServer.Tests/ReverseFunction.cs
+++ b/tests/AwsLambdaTestServer.Tests/ReverseFunction.cs
@@ -4,6 +4,7 @@
 using Amazon.Lambda.RuntimeSupport;
 using Amazon.Lambda.Serialization.Json;
 
+#pragma warning disable IDE0130
 namespace MyFunctions;
 
 public static class ReverseFunction

--- a/tests/AwsLambdaTestServer.Tests/ReverseFunctionTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/ReverseFunctionTests.cs
@@ -4,6 +4,7 @@
 using System.Text.Json;
 using MartinCostello.Testing.AwsLambdaTestServer;
 
+#pragma warning disable IDE0130
 namespace MyFunctions;
 
 public static class ReverseFunctionTests

--- a/tests/AwsLambdaTestServer.Tests/ReverseFunctionWithCustomOptionsTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/ReverseFunctionWithCustomOptionsTests.cs
@@ -4,6 +4,7 @@
 using System.Text.Json;
 using MartinCostello.Testing.AwsLambdaTestServer;
 
+#pragma warning disable IDE0130
 namespace MyFunctions;
 
 public static class ReverseFunctionWithCustomOptionsTests

--- a/tests/AwsLambdaTestServer.Tests/ReverseFunctionWithLoggingTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/ReverseFunctionWithLoggingTests.cs
@@ -7,6 +7,7 @@ using MartinCostello.Testing.AwsLambdaTestServer;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
+#pragma warning disable IDE0130
 namespace MyFunctions;
 
 public class ReverseFunctionWithLoggingTests(ITestOutputHelper outputHelper) : ITestOutputHelperAccessor

--- a/tests/AwsLambdaTestServer.Tests/ReverseFunctionWithMobileSdkTests.cs
+++ b/tests/AwsLambdaTestServer.Tests/ReverseFunctionWithMobileSdkTests.cs
@@ -4,6 +4,7 @@
 using System.Text.Json;
 using MartinCostello.Testing.AwsLambdaTestServer;
 
+#pragma warning disable IDE0130
 namespace MyFunctions;
 
 public static class ReverseFunctionWithMobileSdkTests


### PR DESCRIPTION
- Move rule suppressions to `ruleset` file.
- Disable CA1515.
- Remove redundant package references.
- Suppress IDE0130.
