### PR TITLE
Remove runtime responses once written

### DIFF
--- a/src/AwsLambdaTestServer/RuntimeHandler.cs
+++ b/src/AwsLambdaTestServer/RuntimeHandler.cs
@@ -330,7 +330,11 @@ internal sealed class RuntimeHandler : IDisposable
         bool isSuccessful,
         CancellationToken cancellationToken)
     {
-        var context = _responses[awsRequestId];
+        if (!_responses.TryRemove(awsRequestId, out var context))
+        {
+            throw new InvalidOperationException($"Failed to complete channel for AWS request Id {awsRequestId}.");
+        }
+
         context.DurationTimer!.Stop();
 
         Logger?.LogInformation(


### PR DESCRIPTION
Fix memory leak from build up of `ResponseContext` instances by removing them from the dictionary once used to write the `LambdaTestResponse` to the associated channel.

Discovered by https://github.com/martincostello/alexa-london-travel/pull/1463.