### PR TITLE
Avoid dependabot error

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -46,7 +46,7 @@
     <AssemblyVersion>0.9.0.0</AssemblyVersion>
     <VersionPrefix>0.9.1</VersionPrefix>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(GITHUB_ACTIONS)' != '' ">
+  <PropertyGroup Condition=" '$(GITHUB_ACTIONS)' != '' AND '$(DEPENDABOT_JOB_ID)' == '' ">
     <VersionSuffix Condition=" '$(VersionSuffix)' == '' AND '$(GITHUB_HEAD_REF)' == '' ">preview.$(GITHUB_RUN_NUMBER)</VersionSuffix>
     <VersionSuffix Condition=" '$(VersionSuffix)' == '' AND '$(GITHUB_HEAD_REF)' != '' ">pr.$(GITHUB_REF_NAME.Replace('/merge', '')).$(GITHUB_RUN_NUMBER)</VersionSuffix>
     <VersionPrefix Condition=" $(GITHUB_REF.StartsWith(`refs/tags/v`)) ">$(GITHUB_REF.Replace('refs/tags/v', ''))</VersionPrefix>


### PR DESCRIPTION
Avoid "not a valid version string" error when dependabot jobs run.
