### PR TITLE
Add SDK hint paths

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,12 +1,16 @@
 {
   "name": "C# (.NET)",
-  "extensions": [
-    "editorconfig.editorconfig",
-    "ms-dotnettools.csharp",
-    "ms-vscode.PowerShell"
-  ],
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "editorconfig.editorconfig",
+        "ms-dotnettools.csharp",
+        "ms-vscode.PowerShell"
+      ]
+    }
+  },
   "postCreateCommand": "./build.ps1 -SkipTests",
   "remoteEnv": {
-    "PATH": "/root/.dotnet/tools:${containerWorkspaceFolder}/.dotnetcli:${containerEnv:PATH}"
+    "PATH": "/root/.dotnet/tools:${containerWorkspaceFolder}/.dotnet:${containerEnv:PATH}"
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .DS_Store
-.dotnetcli
+.dotnet
 .idea
 .metadata
 .settings

--- a/build.ps1
+++ b/build.ps1
@@ -42,7 +42,7 @@ else {
 
 if ($installDotNetSdk) {
 
-    ${env:DOTNET_INSTALL_DIR} = Join-Path $solutionPath ".dotnetcli"
+    ${env:DOTNET_INSTALL_DIR} = Join-Path $solutionPath ".dotnet"
     $sdkPath = Join-Path ${env:DOTNET_INSTALL_DIR} "sdk" $dotnetVersion
 
     if (!(Test-Path $sdkPath)) {

--- a/global.json
+++ b/global.json
@@ -1,6 +1,8 @@
 {
   "sdk": {
     "version": "9.0.202",
-    "allowPrerelease": false
+    "allowPrerelease": false,
+    "paths": [ ".dotnet", "$host$" ],
+    "errorMessage": "The required version of the .NET SDK could not be found. Please run ./build.ps1 to bootstrap the .NET SDK."
   }
 }


### PR DESCRIPTION
- Add new .NET 10 properties for locating the .NET SDK.
- Move from `.dotnetcli` to `.dotnet`.
- Avoid using deprecated devcontainer setting.
