### PR TITLE
Remove dependabot reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,6 @@ updates:
     interval: daily
     time: "05:30"
     timezone: Europe/London
-  reviewers:
-    - "martincostello"
 - package-ecosystem: nuget
   directory: "/"
   groups:
@@ -18,11 +16,8 @@ updates:
     interval: daily
     time: "05:30"
     timezone: Europe/London
-  reviewers:
-    - "martincostello"
   open-pull-requests-limit: 99
   ignore:
     - dependency-name: "AWSSDK.SQS"
       update-types: ["version-update:semver-patch"]
     - dependency-name: "Microsoft.AspNetCore.TestHost"
-      versions: ["6.*", "7.*"]


### PR DESCRIPTION
Remove dependabot reviewers as the option is deprecated.
