### PR TITLE
Replace WebHost usage with WebApplication

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,9 +7,9 @@
     <PackageTags>aws;lambda;testserver;testing</PackageTags>
     <UseArtifactsOutput>true</UseArtifactsOutput>
     <UseSharedCompilation>false</UseSharedCompilation>
-    <AssemblyVersion>0.10.0.0</AssemblyVersion>
+    <AssemblyVersion>0.11.0.0</AssemblyVersion>
     <PackageValidationBaselineVersion>0.10.0</PackageValidationBaselineVersion>
-    <VersionPrefix>0.10.1</VersionPrefix>
+    <VersionPrefix>0.11.0</VersionPrefix>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(EnableReferenceTrimmer)' != 'false' and '$(GenerateDocumentationFile)' != 'true' ">
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/README.md
+++ b/README.md
@@ -443,9 +443,9 @@ Result StandardOutput:
 
 #### Custom Lambda Server
 
-It is also possible to use `LambdaTestServer` with a custom [`IServer`][iserver] implementation by overriding the [`CreateServer()`][create-server] method in a derived class.
+It is also possible to use `LambdaTestServer` with a custom [`IServer`][iserver] implementation by overriding the [`ConfigureWebHost()`][configure-webhost] method in a derived class.
 
-This can be used, for example, to host the Lambda test server in a real HTTP server that can be accessed remotely instead of being hosted in-memory with the [`TestServer`][testserver] class.
+This can be used, for example, to host the Lambda test server in a real HTTP server with [Kestrel][kestrel] that can be accessed remotely instead of being hosted in-memory with the [`TestServer`][testserver] class.
 
 For examples of this use case, see the `MinimalApi` example project and its test project in the [samples][samples].
 
@@ -475,13 +475,14 @@ cd lambda-test-server
 
 [build-badge]: https://github.com/martincostello/lambda-test-server/actions/workflows/build.yml/badge.svg?branch=main&event=push
 [build-status]: https://github.com/martincostello/lambda-test-server/actions/workflows/build.yml?query=branch%3Amain+event%3Apush "Continuous Integration for this project"
+[configure-webhost]: https://github.com/martincostello/lambda-test-server/blob/CHANGEME/src/AwsLambdaTestServer/LambdaTestServer.cs#L308-L323 "LambdaTestServer.ConfigureWebHost() method"
 [coverage-badge]: https://codecov.io/gh/martincostello/lambda-test-server/branch/main/graph/badge.svg
 [coverage-report]: https://codecov.io/gh/martincostello/lambda-test-server "Code coverage report for this project"
-[create-server]: https://github.com/martincostello/lambda-test-server/blob/cd5e038660d6e607d06833c03a4a0e8740d643a2/src/AwsLambdaTestServer/LambdaTestServer.cs#L209-L217 "LambdaTestServer.CreateServer() method"
 [custom-lambda-runtime]: https://aws.amazon.com/blogs/developer/net-core-3-0-on-lambda-with-aws-lambdas-custom-runtime/ ".NET Core 3.0 on Lambda with AWS Lambda's Custom Runtime on the AWS Developer Blog"
 [dotnet-sdk]: https://dotnet.microsoft.com/download "Download the .NET SDK"
 [iserver]: https://learn.microsoft.com/dotnet/api/microsoft.aspnetcore.hosting.server.iserver "IServer Interface on docs.microsoft.com"
 [issues]: https://github.com/martincostello/lambda-test-server/issues "Issues for this project on GitHub.com"
+[kestrel]: https://learn.microsoft.com/aspnet/core/fundamentals/servers/kestrel "Kestrel web server in ASP.NET Core"
 [lambda-runtime-support]: https://www.nuget.org/packages/Amazon.Lambda.RuntimeSupport/ "Download Amazon.Lambda.RuntimeSupport from NuGet"
 [license]: https://www.apache.org/licenses/LICENSE-2.0.txt "The Apache 2.0 license"
 [package-badge-downloads]: https://img.shields.io/nuget/dt/MartinCostello.Testing.AwsLambdaTestServer?logo=nuget&label=Downloads&color=blue

--- a/README.md
+++ b/README.md
@@ -475,7 +475,7 @@ cd lambda-test-server
 
 [build-badge]: https://github.com/martincostello/lambda-test-server/actions/workflows/build.yml/badge.svg?branch=main&event=push
 [build-status]: https://github.com/martincostello/lambda-test-server/actions/workflows/build.yml?query=branch%3Amain+event%3Apush "Continuous Integration for this project"
-[configure-webhost]: https://github.com/martincostello/lambda-test-server/blob/CHANGEME/src/AwsLambdaTestServer/LambdaTestServer.cs#L308-L323 "LambdaTestServer.ConfigureWebHost() method"
+[configure-webhost]: https://github.com/martincostello/lambda-test-server/blob/4e78b4077c4b20dcd5b6976c115a4c5bdfeba7d4/src/AwsLambdaTestServer/LambdaTestServer.cs#L308-L323 "LambdaTestServer.ConfigureWebHost() method"
 [coverage-badge]: https://codecov.io/gh/martincostello/lambda-test-server/branch/main/graph/badge.svg
 [coverage-report]: https://codecov.io/gh/martincostello/lambda-test-server "Code coverage report for this project"
 [custom-lambda-runtime]: https://aws.amazon.com/blogs/developer/net-core-3-0-on-lambda-with-aws-lambdas-custom-runtime/ ".NET Core 3.0 on Lambda with AWS Lambda's Custom Runtime on the AWS Developer Blog"

--- a/samples/MinimalApi.Tests/HttpLambdaTestServer.cs
+++ b/samples/MinimalApi.Tests/HttpLambdaTestServer.cs
@@ -4,7 +4,6 @@
 using MartinCostello.Logging.XUnit;
 using MartinCostello.Testing.AwsLambdaTestServer;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -14,33 +13,24 @@ internal sealed class HttpLambdaTestServer : LambdaTestServer, IAsyncLifetime, I
 {
     private readonly CancellationTokenSource _cts = new();
     private bool _disposed;
-    private IWebHost? _webHost;
 
     public ITestOutputHelper? OutputHelper { get; set; }
 
-    public async ValueTask DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-        if (_webHost is not null)
-        {
-            await _webHost.StopAsync();
-        }
-
         Dispose();
+        return ValueTask.CompletedTask;
     }
 
     public async ValueTask InitializeAsync()
         => await StartAsync(_cts.Token);
 
-    protected override IServer CreateServer(IWebHostBuilder builder)
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
-        _webHost = builder
-            .UseKestrel((p) => p.Listen(System.Net.IPAddress.Loopback, 0))
-            .ConfigureServices((services) => services.AddLogging((builder) => builder.AddXUnit(this)))
-            .Build();
+        base.ConfigureWebHost(builder);
 
-        _webHost.Start();
-
-        return _webHost.Services.GetRequiredService<IServer>();
+        builder.UseKestrel((p) => p.Listen(System.Net.IPAddress.Loopback, 0))
+               .ConfigureServices((services) => services.AddLogging((builder) => builder.AddXUnit(this)));
     }
 
     protected override void Dispose(bool disposing)
@@ -49,8 +39,6 @@ internal sealed class HttpLambdaTestServer : LambdaTestServer, IAsyncLifetime, I
         {
             if (disposing)
             {
-                _webHost?.Dispose();
-
                 _cts.Cancel();
                 _cts.Dispose();
             }

--- a/tests/AwsLambdaTestServer.Tests/MartinCostello.Testing.AwsLambdaTestServer.Tests.csproj
+++ b/tests/AwsLambdaTestServer.Tests/MartinCostello.Testing.AwsLambdaTestServer.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Tests for MartinCostello.Testing.AwsLambdaTestServer.</Description>
     <OutputType>Exe</OutputType>
@@ -26,7 +26,7 @@
   </ItemGroup>
   <PropertyGroup>
     <CollectCoverage>true</CollectCoverage>
-    <Threshold>84</Threshold>
+    <Threshold>95,83,95</Threshold>
   </PropertyGroup>
   <ItemGroup>
     <CoverletExclude Include="$([MSBuild]::Escape('[Amazon.Lambda*]*'))" />


### PR DESCRIPTION
- Replace use of `WebHost` with `WebApplication` as the former is marked as obsolete in .NET 10.
- Mark `LambdaTestServer.CreateServer()` as obsolete.
- Refactor environment variable handling.
- Bump version to 0.11.0.
